### PR TITLE
docs: make documentation accurate & up to date with the src/stayawake package

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,17 @@
 
 # StayAwakeBot
 
-StayAwakeBot is a GitHub Actions-native monitoring toolkit. This repository includes the
-`StayAwakeBot Sentinel` component (an availability/checks subtask) that runs on GitHub Actions
-and writes reports back to the repository.
+StayAwakeBot is a distributable (`pip install`-able) Python monitoring **and** security
+toolkit. Under one `stayawake` namespace it ships two bots over a shared `core`:
+
+- **Health sentinel** — a URL/uptime availability monitor (HTTP status, latency, TLS,
+  keyword checks) that writes JSON/markdown reports and a status badge.
+- **Security sentinel** — a supply-chain worm hunter that detects, alerts on, and
+  auto-fixes self-propagating malware (obfuscated loaders, fake fonts, VS Code auto-run
+  tasks, and stealth "evil merges"), opening remediation PRs and gating CI.
+
+Run either bot as a **console script** locally, or as **GitHub Actions** workflows that
+commit reports back to the repository — the same packaged code in both places.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -77,8 +77,9 @@ python -m unittest discover -s tests       # run the test suite
 Notes on checker behaviour
 
 - By default the checker is non-fatal (it will exit successfully) so that reporting
-  and alerting steps can always run in CI. The checker still writes full results
-  to `reports/latest.json` and a timestamped JSON file for each run.
+  and alerting steps can always run in CI. The checker writes full results to
+  `reports/latest.json` and appends a run summary to `reports/history.json`; the
+  reporter produces the dated markdown report (`reports/YYYY-MM-DD/HH-MM-UTC.md`).
 - To make the checker exit with a non-zero code (useful for local debugging), pass
   `--fail-on-unhealthy` to the checker CLI:
 

--- a/docs/SECURITY_ARCHITECTURE.md
+++ b/docs/SECURITY_ARCHITECTURE.md
@@ -1,34 +1,34 @@
 # StayAwakeBot — Security Sentinel Architecture
 
-A worm-hunting / auto-fixing / preventing subsystem that reuses the bot's proven
+A worm-hunting / auto-fixing / preventing bot that reuses the toolkit's proven
 `gather → report → alert → commit` pipeline. Built data-driven and layered so new
 threats are added as configuration, not code.
 
 ## Pillars
 - **Detect** — scan local & remote repos for known indicators (IoCs) and evil merges.
-- **Report/Alert** — JSON + markdown + badge; Slack + GitHub issues (Phase 2).
-- **Auto-fix** — quarantine/strip via PRs, never force-push (Phase 3, dry-run default).
-- **Prevent** — reusable CI gate + pre-commit + CI-token hardening (Phase 4).
+- **Report/Alert** — JSON + markdown + badge; Slack + GitHub issues.
+- **Auto-fix** — quarantine/strip via PRs, never force-push (dry-run by default).
+- **Prevent** — reusable CI gate + pre-commit + CI-token hardening.
 
 ## Layers (SRP)
 ```
-config (data) ─► signature engine ─► matchers ─► findings ─► scanner ─► report/alert ─► remediator(PR)
+signatures (data) ─► signature engine ─► matchers ─► findings ─► scanner ─► report/alert ─► remediator(PR)
 ```
-- **Signatures** (`config/security_signatures.yml`): IoCs as data. New threat = new entry.
+- **Signatures** (`src/stayawake/bots/security/data/signatures.yml`, packaged): IoCs as data. New threat = new entry.
 - **Matchers** (`security/matchers/`, Strategy): one technique each, selected by a
   signature's `matcher` field — `content`, `filename`, `structural-json`, `heuristic`, `git-history`.
 - **Targets** (`security/targets/`, DIP): `LocalRepoTarget` and `RemoteRepoTarget`
   (sandboxed shallow clone, read-only) share one interface.
 - **Scanner** (`security/scanner.py`): runs matchers over a target → `ScanResult`; applies allowlist.
 - **Findings** (`security/models.py`): typed `Severity`/`Finding`/`ScanResult`.
-- **Shared** (`shared + shared/adapters`): reused by both subtasks (DRY).
+- **Shared** (`core` + `core/adapters`): reused by both bots (DRY).
 
 ## Safety / threat model
 - **Never executes scanned code** — static analysis + git plumbing only.
 - Remote targets cloned into ephemeral sandboxes (`core.hooksPath=/dev/null`, no prompts), removed after.
-- Remediation (Phase 3) defaults to **report-only**; fixes go through **PRs**, never force-push to main.
-- The bot's `contents: write` token is high-value — Phase 4 scopes it and hardens the auto-commit step
-  (this is the exact surface the worm used to inject `2fc2e43`).
+- Remediation defaults to **report-only**; fixes go through **PRs**, never force-push to main.
+- The bot's `contents: write` token is high-value — the prevention layer scopes it and hardens the
+  auto-commit step (this is the exact surface the worm used to inject its payload via an evil merge).
 
 ## Detected vectors (from the live incident)
 1. Obfuscated loader in `postcss.config.*` (content + oversized-line heuristic)
@@ -41,39 +41,40 @@ config (data) ─► signature engine ─► matchers ─► findings ─► sca
 ## Config
 - `config/security.yml` — targets (local globs + GitHub users/orgs), exclude dirs, remediation mode,
   allowlist, alert routing.
-- `config/security_signatures.yml` — the signature database.
+- The signature database is shipped inside the package
+  (`src/stayawake/bots/security/data/signatures.yml`); the installed scanner is self-contained.
+  Override it explicitly with `--signatures <path>` if you need a custom DB.
 
 ## CLI / pipeline scripts
-- `src/stayawake/bots/security/cli/scan.py (+ security/service.py)` — Phase 1 (detect → `reports/security/latest.json` + `latest.md`).
-- (Phase 2) `security_report.py` / `security_alert.py`; (Phase 3) `security_remediate.py`.
+- `security/cli/scan.py` (+ `security/service.py`) — detect → `reports/security/latest.json` + `latest.md`.
+- `security/cli/report.py` · `security/cli/alert.py` · `security/cli/remediate.py` — report, alert, remediate.
 
-## Phasing
-1. **Detect (this PR)** — engine + matchers + scanner CLI + tests.
-2. **Alert** — Slack/issues + security badge + scheduled `security-sentinel.yml`.
-3. **Auto-fix** — `remediator` (dry-run → PR) + history-purge helper.
-4. **Prevent** — composite `worm-scan` Action + pre-commit + CI hardening.
+Installed as console scripts: `stayawake-security-scan` · `-report` · `-alert` · `-remediate`
+(or `python -m stayawake.bots.security.cli.<action>`).
 
 ## Testing
-`tests/security/` — inert fixtures (clean vs infected) covering every matcher, plus a real
-evil-merge git fixture. Run: `python -m unittest discover -s tests/security`.
+`tests/bots/security/` — inert fixtures (clean vs infected) covering every matcher, plus a real
+evil-merge git fixture. Run (package installed): `python -m unittest discover -s tests`.
 
-## Remediation (Phase 3)
+## Remediation
 
 `stayawake-security-remediate [--apply]` — dry-run by default. With
 `--apply` it strips/quarantines worm artifacts (originals backed up to `.malware-quarantine/`)
 and commits the fix to a `security/auto-clean-<stamp>` branch — never main, never force-pushed.
 Evil-merge findings are reported as manual (need a history rewrite).
 
+`--apply --open-pr` pushes a stable `security/auto-clean` branch and opens **one rolling
+PR per repo**, targeting the default branch for review. Before opening it checks the API for
+an existing open PR from that branch and updates it instead of creating a duplicate. Work is
+isolated in a git worktree; it never commits to or force-pushes the default branch.
+
 ## Prevention
 
 A reusable `worm-scan` composite Action (`.github/actions/worm-scan`) gates PRs/merges in
 any repo (`worm-guard.yml`), a portable `prevent/pre-commit` hook blocks local commits,
 and `prevent/SECURITY_BASELINE.md` covers branch protection + token/Action hardening.
-
-`--apply --open-pr` pushes a stable `security/auto-clean` branch and opens **one rolling
-PR per repo**, targeting the default branch for review. Before opening it checks the API for
-an existing open PR from that branch and updates it instead of creating a duplicate. Work is
-isolated in a git worktree; it never commits to or force-pushes the default branch.
+The Action installs the published scanner (`pip install "stayawake @ git+…@<ref>"`) rather
+than cloning, so the gate runs the same code as the package.
 
 ## Trigger model (event-driven, not scheduled)
 
@@ -84,11 +85,10 @@ wasteful and reactive.
 | Where | Trigger | What runs |
 |-------|---------|-----------|
 | Hosted — gate | `pull_request` + `push` (code paths) | `worm-guard` blocks infection from landing (read-only, fail-on-findings) |
-| Hosted — sentinel | `push` to `main` (merge) + `workflow_dispatch` | scan the repo, refresh badge/status, alert, commit report |
-| Local — CLI | on demand | `security_scan` over all dev roots; `security_remediate [--apply] [--open-pr]` fixes each repo |
+| Hosted — sentinel | `push` to `main` (merge) + `workflow_dispatch` + weekly backstop | scan the repo, refresh badge/status, alert, commit report |
+| Local — CLI | on demand | `stayawake-security-scan` over all dev roots; `stayawake-security-remediate [--apply] [--open-pr]` fixes each repo |
 | Availability | `schedule` (*/5) | uptime genuinely needs polling — the one place a clock is correct |
 
 Org-wide coverage is **distributed**: every repo runs its own `worm-guard` on its own
-events, rather than a central poller sweeping the org on a timer. A periodic backstop
-(e.g. weekly) is optional — enable a `schedule:` only if you want to catch newly-added
-signatures applied to old code.
+events, rather than a central poller sweeping the org on a timer. A weekly backstop catches
+newly-added signatures applied to old code.

--- a/prevent/SECURITY_BASELINE.md
+++ b/prevent/SECURITY_BASELINE.md
@@ -51,7 +51,7 @@ auto-run tasks, and `.gitignore` worm markers. Bypass a false positive with `--n
 ## 5. Recovery
 If the gate flags a repo, clean it:
 ```bash
-python -m security.cli.remediate --apply   # dry-run first (omit --apply)
+stayawake-security-remediate --apply   # dry-run first (omit --apply)
 ```
 Evil merges already in history need a `git filter-repo` purge + force-push after everyone
 on the team has cleaned their machines.

--- a/prevent/pre-commit
+++ b/prevent/pre-commit
@@ -28,7 +28,7 @@ done <<< "$staged"
 if [ "$fail" = 1 ]; then
   echo ""
   echo "✋ Commit blocked — worm indicators detected (StayAwakeBot worm-guard)."
-  echo "   Real positive? Clean with: python -m security.cli.remediate --apply"
+  echo "   Real positive? Clean with: stayawake-security-remediate --apply"
   echo "   False positive?  Bypass with: git commit --no-verify"
   exit 1
 fi


### PR DESCRIPTION
## Summary

Corrects stale references left over from the pre-refactor (`shared/health/security`)
layout so the docs match the current `src/stayawake/` package.

## Changes
- **docs/SECURITY_ARCHITECTURE.md**: packaged signature DB path
  (`src/stayawake/bots/security/data/signatures.yml`), `core`/`core.adapters`
  (not `shared`), `security/cli/*` module names, `tests/bots/security`, and
  present-tense capabilities (dropped "Phase N"/"(this PR)" framing). Removed an
  unverifiable evil-merge SHA.
- **README.md**: fixed contradictory report claim — checker writes `latest.json`
  + appends `history.json`; reporter emits the dated markdown report (no per-run JSON).
- **prevent/SECURITY_BASELINE.md** + **prevent/pre-commit**:
  `python -m security.cli.remediate` → `stayawake-security-remediate`.

No code changes; ARCHITECTURE.md and CONTRIBUTING.md were already accurate.