### PR TITLE
docs: add Usage section and fix custom-signatures reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,66 @@ commit reports back to the repository — the same packaged code in both places.
 
 ![StayAwakeBot architecture](public/stayawakebot_architecture.svg)
 
+## Usage
+
+StayAwakeBot installs as a Python package and exposes both bots as **console scripts**.
+The same commands run locally or inside the bundled GitHub Actions workflows.
+
+### Install
+
+```bash
+pip install "stayawake @ git+https://github.com/Ndevu12/stayAwakeBot@main"   # or: pipx install "stayawake @ git+…"
+# from a clone, for development:
+pip install -e .
+```
+
+### Health bot — uptime monitoring
+
+Run the pipeline against `config/urls.yml`:
+
+```bash
+stayawake-health-check  --config config/urls.yml   # probe URLs → reports/latest.json
+stayawake-health-report                            # build status.json, history, dated .md, badge
+stayawake-health-alert                             # Slack alert on failures / recoveries
+```
+
+Add `--fail-on-unhealthy` to `check` to exit non-zero when any URL is down (handy locally;
+CI keeps it non-fatal so reports always generate).
+
+### Security bot — worm hunting
+
+```bash
+stayawake-security-scan --config config/security.yml --local-only   # scan local repos → reports/security/latest.json
+stayawake-security-report                                           # status + security badge
+stayawake-security-alert                                            # Slack + GitHub issue on findings
+```
+
+Remediation is **safe by default (dry-run)**:
+
+```bash
+stayawake-security-remediate                    # dry-run: show what would be fixed
+stayawake-security-remediate --apply            # strip/quarantine worm artifacts on a security/auto-clean branch
+stayawake-security-remediate --apply --open-pr  # also open one rolling PR per repo
+stayawake-security-remediate --remote           # operate on remote GitHub targets from config
+```
+
+Drop `--local-only` to also scan the GitHub users/orgs listed in `config/security.yml`.
+Use `--fail-on-findings` to make `scan` exit non-zero (the CI gate uses this).
+
+### Environment / secrets
+
+- `SLACK_WEBHOOK_URL` — enables Slack alerts (both bots).
+- `GH_SECURITY_TOKEN` (or `GITHUB_TOKEN`) — required for remote scans and opening issues / PRs.
+
+### In GitHub Actions
+
+The bundled workflows run these for you:
+
+- `stayawake-sentinel.yml` — health checks on a `*/5` cron.
+- `security-sentinel.yml` — security scan on push to `main` + manual dispatch + weekly backstop.
+- `security-remediate.yml` — remediation (dispatch + weekly).
+- `worm-guard.yml` — blocks infected / evil-merge changes on every PR and push.
+
 ## Quick Setup
 
 1. Fork the repo.

--- a/docs/SECURITY_ARCHITECTURE.md
+++ b/docs/SECURITY_ARCHITECTURE.md
@@ -43,7 +43,7 @@ signatures (data) ─► signature engine ─► matchers ─► findings ─►
   allowlist, alert routing.
 - The signature database is shipped inside the package
   (`src/stayawake/bots/security/data/signatures.yml`); the installed scanner is self-contained.
-  Override it explicitly with `--signatures <path>` if you need a custom DB.
+  Point at a custom DB by setting `settings.signatures_path` in `config/security.yml`.
 
 ## CLI / pipeline scripts
 - `security/cli/scan.py` (+ `security/service.py`) — detect → `reports/security/latest.json` + `latest.md`.


### PR DESCRIPTION
- README: add a Usage section covering install (pip/pipx), both bots' console scripts with real flags, env/secrets, and the bundled GitHub Actions workflows
- security architecture: custom signature DB is set via settings.signatures_path in config, not a --signatures flag