### PR TITLE
docs: slim README to an overview; move detail into docs/

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,158 +23,23 @@ commit reports back to the repository — the same packaged code in both places.
 
 ![StayAwakeBot architecture](public/stayawakebot_architecture.svg)
 
-## Usage
-
-StayAwakeBot installs as a Python package and exposes both bots as **console scripts**.
-The same commands run locally or inside the bundled GitHub Actions workflows.
-
-### Install
+## Quick start
 
 ```bash
-pip install "stayawake @ git+https://github.com/Ndevu12/stayAwakeBot@main"   # or: pipx install "stayawake @ git+…"
-# from a clone, for development:
-pip install -e .
+pip install "stayawake @ git+https://github.com/Ndevu12/stayAwakeBot@main"
+stayawake-health-check  --config config/urls.yml                    # uptime check
+stayawake-security-scan --config config/security.yml --local-only   # worm scan
 ```
 
-### Health bot — uptime monitoring
+## Documentation
 
-Run the pipeline against `config/urls.yml`:
+- [Usage](docs/USAGE.md) — install, run both bots, secrets, GitHub Actions, deploy your own
+- [Configuration & Reports](docs/CONFIGURATION.md) — config file fields and report formats
+- [Architecture](docs/ARCHITECTURE.md) — package layout and design principles
+- [Security architecture](docs/SECURITY_ARCHITECTURE.md) — detection, remediation, prevention
+- [Security baseline](prevent/SECURITY_BASELINE.md) — hardening checklist for any repo
+- [Contributing](CONTRIBUTING.md) — development setup and guidelines
 
-```bash
-stayawake-health-check  --config config/urls.yml   # probe URLs → reports/latest.json
-stayawake-health-report                            # build status.json, history, dated .md, badge
-stayawake-health-alert                             # Slack alert on failures / recoveries
-```
+## License
 
-Add `--fail-on-unhealthy` to `check` to exit non-zero when any URL is down (handy locally;
-CI keeps it non-fatal so reports always generate).
-
-### Security bot — worm hunting
-
-```bash
-stayawake-security-scan --config config/security.yml --local-only   # scan local repos → reports/security/latest.json
-stayawake-security-report                                           # status + security badge
-stayawake-security-alert                                            # Slack + GitHub issue on findings
-```
-
-Remediation is **safe by default (dry-run)**:
-
-```bash
-stayawake-security-remediate                    # dry-run: show what would be fixed
-stayawake-security-remediate --apply            # strip/quarantine worm artifacts on a security/auto-clean branch
-stayawake-security-remediate --apply --open-pr  # also open one rolling PR per repo
-stayawake-security-remediate --remote           # operate on remote GitHub targets from config
-```
-
-Drop `--local-only` to also scan the GitHub users/orgs listed in `config/security.yml`.
-Use `--fail-on-findings` to make `scan` exit non-zero (the CI gate uses this).
-
-### Local defense-in-depth (hooks + audit)
-
-Harden a developer machine with layered, dependency-free git hooks:
-
-```bash
-prevent/install-hooks.sh                 # this repo: pre-commit + post-merge + post-checkout
-prevent/install-hooks.sh --template      # auto-protect all FUTURE clones (init.templateDir)
-prevent/install-hooks.sh --all ~/dev     # install into every existing repo under a root
-```
-
-- **pre-commit** blocks committing worm artifacts (outgoing).
-- **post-merge / post-checkout** scan code that *arrives* via pull/merge or clone — the
-  layer that catches **evil merges**, the worm's real spread vector.
-
-Audit the machine's security posture (cached GitHub credential, VS Code auto-run / Workspace Trust):
-
-```bash
-stayawake-security-audit                 # advisory; add --fail-on-issues for scripts/CI
-```
-
-### Environment / secrets
-
-- `SLACK_WEBHOOK_URL` — enables Slack alerts (both bots).
-- `GH_SECURITY_TOKEN` (or `GITHUB_TOKEN`) — required for remote scans and opening issues / PRs.
-
-### In GitHub Actions
-
-The bundled workflows run these for you:
-
-- `stayawake-sentinel.yml` — health checks on a `*/5` cron.
-- `security-sentinel.yml` — security scan on push to `main` + manual dispatch + weekly backstop.
-- `security-remediate.yml` — remediation (dispatch + weekly).
-- `worm-guard.yml` — blocks infected / evil-merge changes on every PR and push.
-
-## Quick Setup
-
-1. Fork the repo.
-2. Edit `config/urls.yml` with your URLs and settings.
-3. (Optional) Add `SLACK_WEBHOOK_URL` and `GITHUB_TOKEN` to repository secrets.
-4. Push — the workflow will run on schedule and on push to `config/urls.yml`.
-
-## Configuration reference
-
-`config/urls.yml` fields:
-
-- `settings` (global defaults)
-  - `timeout_seconds`: int — request timeout in seconds
-  - `retries`: int — number of retries on failure
-  - `user_agent`: string — User-Agent header
-  - `alert_on_failure`: bool — enable failure alerts
-  - `alert_on_recovery`: bool — enable recovery alerts
-  - `consecutive_failures_before_alert`: int — require this many consecutive failures before alerting
-
-- `urls` (list of URLs to check)
-  - `name` (required): friendly name
-  - `url` (required): full URL to check
-  - `expected_status`: int — expected HTTP status (e.g., 200)
-  - `max_response_ms`: int | null — threshold in milliseconds
-  - `check_ssl`: bool — inspect TLS certificate (only for https)
-  - `keyword`: string — fail if this substring not found in response body (case-insensitive)
-  - `tags`: list[string] — grouping tags
-  - `timeout_seconds`: int — per-URL override of timeout
-
-## Reports
-
-All reports are stored under the `reports/` directory committed back to the repo.
-
-- `reports/latest.json` — latest raw results
-- `reports/history.json` — append-only history of runs
-- `reports/status.json` — machine-readable summary of current status
-- `reports/YYYY-MM-DD/HH-MM-UTC.md` — human-readable markdown report for each run
-
-Note: The checker now writes a richer `latest.json` that includes a `summary` block
-and an `any_unhealthy` boolean. The reporter appends run summaries to `reports/history.json`,
-so per-run JSON files are not created by the checker.
-
-## Local development
-
-The project is a standard `pyproject.toml` package — install it (editable) and run
-the console scripts:
-
-```bash
-python -m venv .venv && source .venv/bin/activate
-pip install -e .
-stayawake-health-check --config config/urls.yml
-stayawake-health-report
-stayawake-health-alert
-stayawake-security-scan --config config/security.yml
-python -m unittest discover -s tests       # run the test suite
-```
-
-`pyproject.toml` is the single source of truth for dependencies and packaging.
-
-Notes on checker behaviour
-
-- By default the checker is non-fatal (it will exit successfully) so that reporting
-  and alerting steps can always run in CI. The checker writes full results to
-  `reports/latest.json` and appends a run summary to `reports/history.json`; the
-  reporter produces the dated markdown report (`reports/YYYY-MM-DD/HH-MM-UTC.md`).
-- To make the checker exit with a non-zero code (useful for local debugging), pass
-  `--fail-on-unhealthy` to the checker CLI:
-
-```bash
-stayawake-health-check --config config/urls.yml --fail-on-unhealthy
-```
-
-This will cause the checker to return a non-zero exit code if any URL was flagged
-unhealthy. In CI the default non-failing behavior is recommended so that reports
-are always generated and committed.
+MIT — see [LICENSE](LICENSE).

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,0 +1,63 @@
+# StayAwakeBot — Configuration & Reports
+
+## `config/urls.yml` (health bot)
+
+```yaml
+settings:            # global defaults
+  timeout_seconds: 10
+  retries: 1
+  user_agent: StayAwakeBot
+  alert_on_failure: true
+  alert_on_recovery: true
+  consecutive_failures_before_alert: 1
+urls:
+  - name: Example
+    url: https://example.com
+    expected_status: 200
+    max_response_ms: 2000
+    check_ssl: true
+    keyword: Example Domain
+    tags: [public]
+    timeout_seconds: 5      # per-URL override
+```
+
+**`settings`** (global defaults)
+- `timeout_seconds` (int) — request timeout in seconds
+- `retries` (int) — number of retries on failure
+- `user_agent` (string) — User-Agent header
+- `alert_on_failure` (bool) — enable failure alerts
+- `alert_on_recovery` (bool) — enable recovery alerts
+- `consecutive_failures_before_alert` (int) — require this many consecutive failures before alerting
+
+**`urls`** (list of URLs to check)
+- `name` (required) — friendly name
+- `url` (required) — full URL to check
+- `expected_status` (int) — expected HTTP status (e.g. 200)
+- `max_response_ms` (int | null) — latency threshold in milliseconds
+- `check_ssl` (bool) — inspect the TLS certificate (https only)
+- `keyword` (string) — fail if this substring is absent from the body (case-insensitive)
+- `tags` (list[string]) — grouping tags
+- `timeout_seconds` (int) — per-URL override of the global timeout
+
+## `config/security.yml` (security bot)
+
+Targets (local globs + GitHub users/orgs), exclude dirs, remediation mode, allowlist,
+and alert routing. The signature database ships **inside the package**; point at a custom
+DB with `settings.signatures_path`. Full field reference and the layered design live in
+[SECURITY_ARCHITECTURE.md](SECURITY_ARCHITECTURE.md).
+
+## Reports
+
+Reports are written under `reports/` and committed back to the repo.
+
+| File | Contents |
+|------|----------|
+| `reports/latest.json` | latest raw results (`summary` block + `any_unhealthy`) |
+| `reports/history.json` | append-only history of run summaries |
+| `reports/status.json` | machine-readable current status |
+| `reports/YYYY-MM-DD/HH-MM-UTC.md` | human-readable per-run markdown report |
+| `reports/security/latest.{json,md}` | latest security scan results |
+
+The checker writes `latest.json` and appends to `history.json`; the **reporter** produces
+`status.json`, the dated markdown report, and the badge. (The checker does not write per-run
+JSON files.)

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,0 +1,102 @@
+# StayAwakeBot — Usage
+
+StayAwakeBot installs as a Python package and exposes both bots as **console scripts**.
+The same commands run locally or inside the bundled GitHub Actions workflows.
+
+## Install
+
+```bash
+pip install "stayawake @ git+https://github.com/Ndevu12/stayAwakeBot@main"   # or: pipx install "stayawake @ git+…"
+# from a clone, for development:
+pip install -e .
+```
+
+## Health bot — uptime monitoring
+
+Run the pipeline against `config/urls.yml`:
+
+```bash
+stayawake-health-check  --config config/urls.yml   # probe URLs → reports/latest.json
+stayawake-health-report                            # build status.json, history, dated .md, badge
+stayawake-health-alert                             # Slack alert on failures / recoveries
+```
+
+By default `check` is **non-fatal** (exits 0) so reporting/alerting always run in CI.
+Add `--fail-on-unhealthy` to exit non-zero when any URL is down (handy locally):
+
+```bash
+stayawake-health-check --config config/urls.yml --fail-on-unhealthy
+```
+
+## Security bot — worm hunting
+
+```bash
+stayawake-security-scan --config config/security.yml --local-only   # scan local repos → reports/security/latest.json
+stayawake-security-report                                           # status + security badge
+stayawake-security-alert                                            # Slack + GitHub issue on findings
+```
+
+Remediation is **safe by default (dry-run)**:
+
+```bash
+stayawake-security-remediate                    # dry-run: show what would be fixed
+stayawake-security-remediate --apply            # strip/quarantine worm artifacts on a security/auto-clean branch
+stayawake-security-remediate --apply --open-pr  # also open one rolling PR per repo
+stayawake-security-remediate --remote           # operate on remote GitHub targets from config
+```
+
+Drop `--local-only` to also scan the GitHub users/orgs listed in `config/security.yml`.
+Use `--fail-on-findings` to make `scan` exit non-zero (the CI gate uses this).
+See [SECURITY_ARCHITECTURE.md](SECURITY_ARCHITECTURE.md) for how detection / remediation work.
+
+## Local defense-in-depth (hooks + audit)
+
+Harden a developer machine with layered, dependency-free git hooks:
+
+```bash
+prevent/install-hooks.sh                 # this repo: pre-commit + post-merge + post-checkout
+prevent/install-hooks.sh --template      # auto-protect all FUTURE clones (init.templateDir)
+prevent/install-hooks.sh --all ~/dev     # install into every existing repo under a root
+```
+
+- **pre-commit** blocks committing worm artifacts (outgoing).
+- **post-merge / post-checkout** scan code that *arrives* via pull/merge or clone — the
+  layer that catches **evil merges**, the worm's real spread vector.
+
+Audit the machine's security posture (cached GitHub credential, VS Code auto-run / Workspace Trust):
+
+```bash
+stayawake-security-audit                 # advisory; add --fail-on-issues for scripts/CI
+```
+
+## Environment / secrets
+
+- `SLACK_WEBHOOK_URL` — enables Slack alerts (both bots).
+- `GH_SECURITY_TOKEN` (or `GITHUB_TOKEN`) — required for remote scans and opening issues / PRs.
+
+## In GitHub Actions
+
+The bundled workflows run these for you:
+
+- `stayawake-sentinel.yml` — health checks on a `*/5` cron.
+- `security-sentinel.yml` — security scan on push to `main` + manual dispatch + weekly backstop.
+- `security-remediate.yml` — remediation (dispatch + weekly).
+- `worm-guard.yml` — blocks infected / evil-merge changes on every PR and push.
+
+## Deploy your own monitor
+
+1. Fork the repo.
+2. Edit `config/urls.yml` with your URLs and settings (see [CONFIGURATION.md](CONFIGURATION.md)).
+3. (Optional) Add `SLACK_WEBHOOK_URL` and `GITHUB_TOKEN` to repository secrets.
+4. Push — the workflow runs on schedule and on push to `config/urls.yml`.
+
+## Local development
+
+```bash
+python -m venv .venv && source .venv/bin/activate
+pip install -e .
+python -m unittest discover -s tests       # run the test suite (package must be installed)
+```
+
+`pyproject.toml` is the single source of truth for dependencies and packaging.
+For contribution guidelines and layout, see [CONTRIBUTING.md](../CONTRIBUTING.md).


### PR DESCRIPTION
- README: badges, description, architecture, quick start, and a documentation index
- docs/USAGE.md: install, both bots, secrets, GitHub Actions, deploy-your-own, dev install
- docs/CONFIGURATION.md: config/urls.yml + config/security.yml pointers + report formats