### PR TITLE
feat(security): enforce quarantine .gitignore on remediation and PRs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,8 +205,9 @@ marimo/_static/
 marimo/_lsp/
 __marimo__/
 
-# local malware quarantine (do not commit)
+# Malware quarantine / remediation artifacts (kept local, never committed)
 .malware-quarantine/
+*.malware-bak
 
 .DS_Store
 

--- a/src/stayawake/bots/security/pr.py
+++ b/src/stayawake/bots/security/pr.py
@@ -80,6 +80,7 @@ def submit_fix_pr(repo: Path, opts, signatures, allowlist, token: str) -> str:
             return f"{slug}: '{base}' already clean — nothing to PR"
 
         remediation.apply(wt, changes, quarantine)
+        remediation.ensure_ignored(wt)   # never commit quarantine/remediation artifacts
         _git(wt, "add", "-A")
         msg = "security: auto-remediate worm indicators\n\n" + \
               "\n".join(f"- {c.action}: {c.path}" for c in changes)

--- a/src/stayawake/bots/security/remediation.py
+++ b/src/stayawake/bots/security/remediation.py
@@ -26,6 +26,12 @@ _ACTIONS = {
 }
 _GITIGNORE_MARKERS = {"branch_structure.json", "temp_auto_push.bat", "temp_interactive_push.bat"}
 
+# Quarantine / remediation artifacts must stay local and never be committed.
+# `ensure_ignored` guarantees a target repo's .gitignore carries these before we
+# `git add` a fix, so backups never leak into a commit or PR.
+_QUARANTINE_COMMENT = "# Malware quarantine / remediation artifacts (kept local, never committed)"
+_QUARANTINE_PATTERNS = (".malware-quarantine/", "*.malware-bak")
+
 
 @dataclass(frozen=True)
 class Change:
@@ -95,6 +101,28 @@ def strip_settings_autorun(text: str) -> str:
     data.pop("task.allowAutomaticTasks", None)
     data.pop("tasks", None)
     return json.dumps(data, indent=2) + "\n"
+
+
+def ensure_ignored(root: Path) -> bool:
+    """Guarantee `root/.gitignore` ignores quarantine/remediation artifacts.
+
+    Appends any missing patterns (and the explanatory comment) idempotently.
+    Returns True if the file was changed. Called before `git add` so backups
+    never land in a commit or PR.
+    """
+    gi = root / ".gitignore"
+    text = gi.read_text(encoding="utf-8", errors="replace") if gi.exists() else ""
+    present = {l.strip() for l in text.splitlines()}
+    missing = [p for p in _QUARANTINE_PATTERNS if p not in present]
+    if not missing:
+        return False
+    block: list[str] = []
+    if _QUARANTINE_COMMENT not in present:
+        block.append(_QUARANTINE_COMMENT)
+    block += missing
+    head = (text.rstrip("\n") + "\n\n") if text.strip() else ""
+    gi.write_text(head + "\n".join(block) + "\n", encoding="utf-8")
+    return True
 
 
 def _backup(root: Path, rel: str, quarantine: Path) -> None:

--- a/src/stayawake/bots/security/remediator.py
+++ b/src/stayawake/bots/security/remediator.py
@@ -93,6 +93,7 @@ def remediate(config_path: str = "config/security.yml", apply: bool = False,
         else:
             was_clean = _is_clean(repo)
             applied = remediation.apply(repo, changes, repo / ".malware-quarantine")
+            remediation.ensure_ignored(repo)   # keep quarantine artifacts out of any commit
             print(f"    → applied {len(applied)} change(s); originals in .malware-quarantine/")
             if was_clean:
                 branch = _commit_branch(repo, applied)

--- a/tests/bots/security/test_remediation.py
+++ b/tests/bots/security/test_remediation.py
@@ -47,5 +47,32 @@ class TestRemediation(unittest.TestCase):
         self.assertNotIn("PAYLOAD_JUNK_HERE", out)
 
 
+class TestEnsureIgnored(unittest.TestCase):
+    def setUp(self):
+        self.repo = Path(tempfile.mkdtemp())
+        self.gi = self.repo / ".gitignore"
+
+    def _lines(self):
+        return self.gi.read_text(encoding="utf-8").splitlines()
+
+    def test_creates_gitignore_when_absent(self):
+        self.assertTrue(remediation.ensure_ignored(self.repo))
+        lines = self._lines()
+        self.assertIn(".malware-quarantine/", lines)
+        self.assertIn("*.malware-bak", lines)
+
+    def test_appends_only_missing_patterns(self):
+        self.gi.write_text("node_modules/\n.malware-quarantine/\n", encoding="utf-8")
+        self.assertTrue(remediation.ensure_ignored(self.repo))
+        lines = self._lines()
+        self.assertEqual(lines.count(".malware-quarantine/"), 1, "must not duplicate")
+        self.assertIn("*.malware-bak", lines)
+        self.assertIn("node_modules/", lines)
+
+    def test_idempotent_no_change_when_present(self):
+        remediation.ensure_ignored(self.repo)
+        self.assertFalse(remediation.ensure_ignored(self.repo), "second call should be a no-op")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Quarantine/remediation backups must stay local and never be committed. This was only true for repos that already ignored .malware-quarantine/. The local remediator runs `git add -A` on target repos, so on any repo lacking that entry the backups would have been committed; *.malware-bak was not ignored anywhere.

- remediation.ensure_ignored(): idempotently append the patterns (.malware-quarantine/, *.malware-bak) + comment to a repo's .gitignore
- call it before staging in both pr.submit_fix_pr and remediator.remediate so every fix PR and local quarantine carries the rules first
- update this repo's own .gitignore to the canonical block
- tests for create / append-missing / idempotent