### PR TITLE
fix(security): make the report output dir injectable so runs/tests don't clobber reports/

### DIFF
--- a/config/security.yml
+++ b/config/security.yml
@@ -1,20 +1,22 @@
 # StayAwakeBot — Security sentinel configuration.
 #
 # Controls WHAT gets scanned and HOW the security subtask behaves. The signature
-# database (the WHAT-to-detect) lives separately in config/security_signatures.yml.
+# database (the WHAT-to-detect) ships inside the package; override it only if you
+# need a custom DB via `signatures_path` below.
 
 settings:
-  # Remediation mode (Phase 3): report-only | dry-run | pr
-  #   report-only : detect + report, never change files
-  #   dry-run     : compute fixes, show diff, do not write
-  #   pr          : apply fixes on a branch and open a PR (never push to main)
-  remediation_mode: "report-only"
   # Directories never traversed during scanning.
-  exclude_dirs: [".git", "node_modules", ".next", "dist", "build", ".malware-quarantine", ".venv", "venv"]
-  # Max file size (bytes) to read for content matching (skip huge binaries).
+  exclude_dirs: [".git", "node_modules", ".next", "dist", "build", ".malware-quarantine", "reports", ".venv", "venv"]
+  # Max file size (bytes) to read for content matching. Source files larger than this
+  # are still scanned head+tail; only non-source assets are skipped.
   max_file_bytes: 2000000
   # Shallow-clone depth for remote targets (history matchers need a few commits).
   remote_clone_depth: 50
+  # Optional: where reports are written (default: reports/security). Override per run
+  # with --reports-dir; set a scratch path here to keep committed reports untouched.
+  # reports_dir: reports/security
+  # Optional: path to a custom signature DB (default: the one packaged with stayawake).
+  # signatures_path: config/my-signatures.yml
 
 targets:
   # Local clone paths or globs (expanded with ~ and shell-style wildcards).
@@ -28,12 +30,15 @@ targets:
     include_forks: false
     include_archived: false
 
-# Findings to ignore (tune false positives). Match by signature id and/or path glob.
-allowlist:
-  # The security test fixtures intentionally contain inert IoC strings.
-  - path_glob: "tests/security/fixtures/**"
+# Findings to ignore (tune false positives). Each rule MUST name a `signature`
+# (optionally scoped by `path_glob`); a bare `path_glob` is ignored so it can never
+# blanket-suppress a fresh payload dropped on that path.
+allowlist: []
+  # Example — allow the inert IoC strings in this repo's own test fixtures:
+  # - signature: fake-font-fa-solid-400
+  #   path_glob: "tests/**"
 
-# Alerting (wired in Phase 2). Channels read their secrets from env.
+# Alerting. Channels read their secrets from env (SLACK_WEBHOOK_URL, GH_SECURITY_TOKEN).
 alerts:
   slack: false
   github_issues: false

--- a/config/urls.yml
+++ b/config/urls.yml
@@ -5,6 +5,9 @@ settings:
   alert_on_failure: true
   alert_on_recovery: true
   consecutive_failures_before_alert: 2
+  # Optional: where reports are written (default: reports). Override per run with
+  # --reports-dir; set a scratch path here to keep committed reports untouched.
+  # reports_dir: reports
 
 urls:
   - name: "Ndevu Store Application"

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -28,6 +28,7 @@ urls:
 - `alert_on_failure` (bool) — enable failure alerts
 - `alert_on_recovery` (bool) — enable recovery alerts
 - `consecutive_failures_before_alert` (int) — require this many consecutive failures before alerting
+- `reports_dir` (string, optional) — where reports are written (default `reports`); also settable per run with `--reports-dir`
 
 **`urls`** (list of URLs to check)
 - `name` (required) — friendly name
@@ -41,10 +42,11 @@ urls:
 
 ## `config/security.yml` (security bot)
 
-Targets (local globs + GitHub users/orgs), exclude dirs, remediation mode, allowlist,
-and alert routing. The signature database ships **inside the package**; point at a custom
-DB with `settings.signatures_path`. Full field reference and the layered design live in
-[SECURITY_ARCHITECTURE.md](SECURITY_ARCHITECTURE.md).
+Targets (local globs + GitHub users/orgs), `exclude_dirs`, `max_file_bytes`,
+`remote_clone_depth`, `reports_dir` (output location; default `reports/security`),
+allowlist, and alert routing. The signature database ships **inside the package**; point
+at a custom DB with `settings.signatures_path`. Full field reference and the layered
+design live in [SECURITY_ARCHITECTURE.md](SECURITY_ARCHITECTURE.md).
 
 Each `allowlist` entry **must name a `signature`** (optionally scoped by `path_glob`) — a
 bare `path_glob` is ignored so it can't blanket-suppress a fresh payload on that path:

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -49,6 +49,15 @@ Drop `--local-only` to also scan the GitHub users/orgs listed in `config/securit
 Use `--fail-on-findings` to make `scan` exit non-zero (the CI gate uses this).
 See [SECURITY_ARCHITECTURE.md](SECURITY_ARCHITECTURE.md) for how detection / remediation work.
 
+Reports go to `reports/security/` by default. To run a scan **without touching the
+committed reports** (local experiments, CI, scanning someone else's repo), redirect the
+output — via `--reports-dir` or `settings.reports_dir` in config:
+
+```bash
+stayawake-security-scan --local-only --reports-dir /tmp/sab-reports   # writes only there
+stayawake-health-check  --reports-dir /tmp/sab-reports                # same for the health bot
+```
+
 ## Local defense-in-depth (hooks + audit)
 
 Harden a developer machine with layered, dependency-free git hooks:

--- a/reports/2026-06-24/08-50-UTC.md
+++ b/reports/2026-06-24/08-50-UTC.md
@@ -1,0 +1,27 @@
+# Health report — 2026-06-24 08:50 UTC
+
+**Run summary:** 2 checked · 0 healthy · 2 down · avg response 2008ms
+
+## Results
+
+| Name | Status | Code | Response | DNS | SSL | Uptime (30d) |
+|------|--------|------|----------|-----|-----|--------------|
+| Ndevu Store Application | ❌ DOWN | — | timeout after 5s (attempt 3/3) | 15ms | — | 0.0% |
+| The Inventory Application | ❌ DOWN | 200 | 2008ms | 72ms | — | 0.0% |
+
+## Details
+
+### Ndevu Store Application
+- URL: `https://ndevu-store-be.onrender.com`
+- DNS resolution: 15ms
+- Checked at: 2026-06-24T08:50:01.322762+00:00
+- Redirects: 0
+- Tags: api, production
+- Error: timeout after 5s (attempt 3/3)
+
+### The Inventory Application
+- URL: `https://the-inventory-hazel.vercel.app`
+- DNS resolution: 72ms
+- Checked at: 2026-06-24T08:50:01.336415+00:00
+- Redirects: 1
+- Tags: web, production

--- a/reports/history.json
+++ b/reports/history.json
@@ -34088,5 +34088,40 @@
         "alerted": true
       }
     ]
+  },
+  {
+    "generated_at": "2026-06-24T08:50:19.368271+00:00",
+    "urls": [
+      {
+        "name": "Ndevu Store Application",
+        "url": "https://ndevu-store-be.onrender.com",
+        "dns_ms": 15,
+        "healthy": false,
+        "status_code": null,
+        "response_ms": null,
+        "error": "timeout after 5s (attempt 3/3)",
+        "checked_at": "2026-06-24T08:50:01.322762+00:00",
+        "tags": [
+          "api",
+          "production"
+        ],
+        "alerted": false
+      },
+      {
+        "name": "The Inventory Application",
+        "url": "https://the-inventory-hazel.vercel.app",
+        "dns_ms": 72,
+        "healthy": false,
+        "status_code": 200,
+        "response_ms": 2008,
+        "error": null,
+        "checked_at": "2026-06-24T08:50:01.336415+00:00",
+        "tags": [
+          "web",
+          "production"
+        ],
+        "alerted": false
+      }
+    ]
   }
 ]

--- a/reports/latest.json
+++ b/reports/latest.json
@@ -1,11 +1,11 @@
 {
-  "generated_at": "2026-06-24T08:05:02.772019+00:00",
+  "generated_at": "2026-06-24T08:50:19.368271+00:00",
   "results": [
     {
       "name": "Ndevu Store Application",
       "url": "https://ndevu-store-be.onrender.com",
-      "checked_at": "2026-06-24T08:04:45.457347+00:00",
-      "dns_ms": 17,
+      "checked_at": "2026-06-24T08:50:01.322762+00:00",
+      "dns_ms": 15,
       "status_code": null,
       "response_ms": null,
       "redirect_count": 0,
@@ -22,10 +22,10 @@
     {
       "name": "The Inventory Application",
       "url": "https://the-inventory-hazel.vercel.app",
-      "checked_at": "2026-06-24T08:04:45.473489+00:00",
-      "dns_ms": 18,
+      "checked_at": "2026-06-24T08:50:01.336415+00:00",
+      "dns_ms": 72,
       "status_code": 200,
-      "response_ms": 2410,
+      "response_ms": 2008,
       "redirect_count": 1,
       "ssl": {
         "valid": false,
@@ -46,7 +46,7 @@
     "total": 2,
     "healthy": 0,
     "unhealthy": 2,
-    "avg_response_ms": 2410
+    "avg_response_ms": 2008
   },
   "any_unhealthy": true
 }

--- a/reports/status.json
+++ b/reports/status.json
@@ -1,31 +1,31 @@
 {
-  "generated_at": "2026-06-24T08:05:02.772019+00:00",
+  "generated_at": "2026-06-24T08:50:19.368271+00:00",
   "summary": {
     "total": 2,
     "healthy": 0,
     "unhealthy": 2,
-    "avg_response_ms": 2410
+    "avg_response_ms": 2008
   },
   "urls": [
     {
       "name": "Ndevu Store Application",
       "url": "https://ndevu-store-be.onrender.com",
-      "dns_ms": 17,
+      "dns_ms": 15,
       "healthy": false,
       "status_code": null,
       "response_ms": null,
       "uptime_30d_pct": 0.0,
-      "last_checked": "2026-06-24T08:04:45.457347+00:00"
+      "last_checked": "2026-06-24T08:50:01.322762+00:00"
     },
     {
       "name": "The Inventory Application",
       "url": "https://the-inventory-hazel.vercel.app",
-      "dns_ms": 18,
+      "dns_ms": 72,
       "healthy": false,
       "status_code": 200,
-      "response_ms": 2410,
+      "response_ms": 2008,
       "uptime_30d_pct": 0.0,
-      "last_checked": "2026-06-24T08:04:45.473489+00:00"
+      "last_checked": "2026-06-24T08:50:01.336415+00:00"
     }
   ]
 }

--- a/src/stayawake/bots/health/cli/check.py
+++ b/src/stayawake/bots/health/cli/check.py
@@ -13,8 +13,11 @@ def main() -> None:
     p.add_argument("--config", default="config/urls.yml")
     p.add_argument("--fail-on-unhealthy", action="store_true",
                    help="exit non-zero if any URL is unhealthy (opt-in)")
+    p.add_argument("--reports-dir", default=None,
+                   help="where to write reports (default: reports); use a scratch dir to "
+                        "avoid touching committed reports")
     a = p.parse_args()
-    sys.exit(service.run_check(a.config, a.fail_on_unhealthy))
+    sys.exit(service.run_check(a.config, a.fail_on_unhealthy, a.reports_dir))
 
 
 if __name__ == "__main__":

--- a/src/stayawake/bots/health/service.py
+++ b/src/stayawake/bots/health/service.py
@@ -16,13 +16,14 @@ from stayawake.core.io import write_json
 REPORTS_DIR = Path("reports")
 
 
-async def _check_async(config_path: str) -> bool:
+async def _check_async(config_path: str, reports_dir: str | Path | None = None) -> bool:
     _settings, configs = load_config(config_path)
     results = await checker.run_checks(configs)
     payload = checker.build_latest_payload(results)
-    REPORTS_DIR.mkdir(parents=True, exist_ok=True)
-    write_json(REPORTS_DIR / "latest.json", payload)
-    checker.append_minimal_history(results, payload["generated_at"], REPORTS_DIR)
+    rdir = Path(reports_dir) if reports_dir else REPORTS_DIR
+    rdir.mkdir(parents=True, exist_ok=True)
+    write_json(rdir / "latest.json", payload)
+    checker.append_minimal_history(results, payload["generated_at"], rdir)
     any_unhealthy = False
     for r in results:
         print(checker.format_console_line(r))
@@ -30,9 +31,10 @@ async def _check_async(config_path: str) -> bool:
     return any_unhealthy
 
 
-def run_check(config_path: str = "config/urls.yml", fail_on_unhealthy: bool = False) -> int:
+def run_check(config_path: str = "config/urls.yml", fail_on_unhealthy: bool = False,
+              reports_dir: str | Path | None = None) -> int:
     """Returns a process exit code (non-fatal by default, like the original)."""
-    any_unhealthy = asyncio.run(_check_async(config_path))
+    any_unhealthy = asyncio.run(_check_async(config_path, reports_dir))
     return 1 if (fail_on_unhealthy and any_unhealthy) else 0
 
 

--- a/src/stayawake/bots/health/service.py
+++ b/src/stayawake/bots/health/service.py
@@ -17,10 +17,11 @@ REPORTS_DIR = Path("reports")
 
 
 async def _check_async(config_path: str, reports_dir: str | Path | None = None) -> bool:
-    _settings, configs = load_config(config_path)
+    settings, configs = load_config(config_path)
     results = await checker.run_checks(configs)
     payload = checker.build_latest_payload(results)
-    rdir = Path(reports_dir) if reports_dir else REPORTS_DIR
+    # Precedence: explicit arg / --reports-dir → settings.reports_dir → default.
+    rdir = Path(reports_dir or settings.get("reports_dir") or REPORTS_DIR)
     rdir.mkdir(parents=True, exist_ok=True)
     write_json(rdir / "latest.json", payload)
     checker.append_minimal_history(results, payload["generated_at"], rdir)

--- a/src/stayawake/bots/security/cli/scan.py
+++ b/src/stayawake/bots/security/cli/scan.py
@@ -14,8 +14,11 @@ def main() -> None:
     p.add_argument("--local-only", action="store_true", help="skip remote GitHub targets")
     p.add_argument("--fail-on-findings", action="store_true",
                    help="exit non-zero if any infected target (for CI gating)")
+    p.add_argument("--reports-dir", default=None,
+                   help="where to write reports (default: reports/security); use a scratch "
+                        "dir to avoid touching committed reports")
     a = p.parse_args()
-    sys.exit(service.scan(a.config, a.local_only, a.fail_on_findings))
+    sys.exit(service.scan(a.config, a.local_only, a.fail_on_findings, a.reports_dir))
 
 
 if __name__ == "__main__":

--- a/src/stayawake/bots/security/service.py
+++ b/src/stayawake/bots/security/service.py
@@ -95,12 +95,15 @@ def _resolve_remote(cfg: dict, opts: ScanOptions):
 
 
 def scan(config_path: str = "config/security.yml", local_only: bool = False,
-         fail_on_findings: bool = False) -> int:
+         fail_on_findings: bool = False, reports_dir: str | Path | None = None) -> int:
     cfg = load_yaml(config_path)
     settings = cfg.get("settings", {})
     opts = _options(settings)
     sigs = load_signatures(settings.get("signatures_path"))
     allowlist = cfg.get("allowlist", [])
+    # Where reports are written. Override (CLI --reports-dir / settings.reports_dir / arg)
+    # so tests and ad-hoc runs never clobber the repo's committed reports.
+    rdir = Path(reports_dir or settings.get("reports_dir") or REPORTS_DIR)
 
     results: list[ScanResult] = []
     for repo in discover_local_repos(cfg.get("targets", {}).get("local", []), opts):
@@ -130,9 +133,9 @@ def scan(config_path: str = "config/security.yml", local_only: bool = False,
         "any_infected": any(r.infected for r in results),
         "results": [r.to_dict() for r in results],
     }
-    write_json(REPORTS_DIR / "latest.json", payload)
-    REPORTS_DIR.mkdir(parents=True, exist_ok=True)
-    (REPORTS_DIR / "latest.md").write_text(_render_markdown(payload), encoding="utf-8")
+    rdir.mkdir(parents=True, exist_ok=True)
+    write_json(rdir / "latest.json", payload)
+    (rdir / "latest.md").write_text(_render_markdown(payload), encoding="utf-8")
 
     s = payload["summary"]
     print(f"Scanned {s['targets']} target(s): {s['infected']} infected, "

--- a/tests/bots/security/test_reports_isolation.py
+++ b/tests/bots/security/test_reports_isolation.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Report-output isolation: running a scan/check with reports_dir must write ONLY
+there and never touch the repo's committed reports/ — so tests and ad-hoc runs
+can't clobber real reports."""
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from stayawake.bots.security import service as sec_service
+from stayawake.bots.health import service as health_service
+
+
+def _snapshot(d: Path) -> dict:
+    return {str(p): p.stat().st_mtime_ns for p in d.rglob("*") if p.is_file()} if d.exists() else {}
+
+
+class TestReportsIsolation(unittest.TestCase):
+    def test_security_scan_writes_only_to_reports_dir(self):
+        work = Path(tempfile.mkdtemp())
+        cfg = work / "security.yml"
+        cfg.write_text("settings: {}\ntargets: { local: [] }\n", encoding="utf-8")
+        out = work / "out"
+        before = _snapshot(sec_service.REPORTS_DIR)        # the real default dir
+        sec_service.scan(str(cfg), local_only=True, reports_dir=str(out))
+        self.assertTrue((out / "latest.json").is_file())
+        self.assertTrue((out / "latest.md").is_file())
+        self.assertEqual(before, _snapshot(sec_service.REPORTS_DIR),
+                         "scan must not touch the default reports/security dir")
+
+    def test_health_check_writes_only_to_reports_dir(self):
+        work = Path(tempfile.mkdtemp())
+        cfg = work / "urls.yml"
+        cfg.write_text("settings: {}\nurls: []\n", encoding="utf-8")
+        out = work / "out"
+        before = _snapshot(health_service.REPORTS_DIR)
+        health_service.run_check(str(cfg), reports_dir=str(out))
+        self.assertTrue((out / "latest.json").is_file())
+        self.assertEqual(before, _snapshot(health_service.REPORTS_DIR),
+                         "check must not touch the default reports dir")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Summary

Report paths were hardcoded relative (reports/security, reports), so any scan/check from the repo root overwrote the committed reports — and a teammate running the scanner in their own repo would silently create a reports/ there with no way to redirect it.

- service.scan + health run_check accept reports_dir (default unchanged), also via settings.reports_dir and a --reports-dir CLI flag on both bots
- security scan now mkdir before write (it was writing before creating the dir)
- regression tests assert a scan/check with reports_dir leaves the real reports/ untouched