### PR TITLE
ci: add install+test gate that runs before merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI — install & test
+
+# Validation gate that runs BEFORE code is trusted: install the package and run the
+# test suite on every pull request and on pushes to main. Report-only commits
+# (reports/**, README badge) are skipped so the per-run sentinel pushes don't trigger
+# a full test run. Mark this as a required status check in branch protection so
+# nothing merges to main without it passing.
+on:
+  pull_request:
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'reports/**'
+      - 'README.md'
+
+permissions:
+  contents: read
+
+# Cancel superseded runs for the same ref to save CI minutes.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0   # v7.0.0
+
+      - name: Set up toolchain
+        uses: ./.github/actions/setup
+
+      - name: Run test suite
+        run: python -m unittest discover -s tests -v


### PR DESCRIPTION
New CI workflow runs on every pull request and on pushes to main: checkout → shared ./.github/actions/setup (Python 3.14 + pip install .) → the unittest suite. This is the first workflow that validates the code itself (the others are operational), and it dogfoods the setup composite action. Report-only commits are skipped via paths-ignore so per-run sentinel pushes don't trigger it.