### PR TITLE
feat(security): ad-hoc local scan targets (paths / --path) + CWD default

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -48,6 +48,11 @@ allowlist, and alert routing. The signature database ships **inside the package*
 at a custom DB with `settings.signatures_path`. Full field reference and the layered
 design live in [SECURITY_ARCHITECTURE.md](SECURITY_ARCHITECTURE.md).
 
+`targets.local` is **optional**: for ad-hoc local scans you can pass paths on the command
+line (`stayawake-security-scan <path>…` / `--path`), and a bare `stayawake-security-scan`
+with nothing configured scans the current repository. A token is never needed for local
+scanning — see [USAGE.md](USAGE.md#ad-hoc-local-scanning-no-token-no-config).
+
 Each `allowlist` entry **must name a `signature`** (optionally scoped by `path_glob`) — a
 bare `path_glob` is ignored so it can't blanket-suppress a fresh payload on that path:
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -36,6 +36,23 @@ stayawake-security-report                                           # status + s
 stayawake-security-alert                                            # Slack + GitHub issue on findings
 ```
 
+### Ad-hoc local scanning (no token, no config)
+
+Scanning local code needs **no GitHub token and no config file** — a token is only
+for cloning private remotes or opening PRs. Point the scanner at paths, or just run it
+inside a repo:
+
+```bash
+stayawake-security-scan                      # no args → scans the repo you're standing in
+stayawake-security-scan ~/dev/some-project   # scan a specific repo (or a folder of repos)
+stayawake-security-scan ./a ./b --path ./c   # several at once (positional and/or --path)
+```
+
+A path may be a single repository or a directory containing many — the scanner walks it
+for git repos. Explicit paths imply `--local-only` (nothing is sent to GitHub). With no
+paths and nothing configured, it scans the current repository (found by walking up to the
+nearest `.git`), so a bare `stayawake-security-scan` "just works" after `pip install`.
+
 Remediation is **safe by default (dry-run)**:
 
 ```bash

--- a/src/stayawake/bots/security/cli/scan.py
+++ b/src/stayawake/bots/security/cli/scan.py
@@ -10,7 +10,13 @@ from stayawake.bots.security import service
 
 def main() -> None:
     p = argparse.ArgumentParser(description="StayAwakeBot security scanner")
-    p.add_argument("--config", default="config/security.yml")
+    p.add_argument("paths", nargs="*",
+                   help="repo or directory paths to scan (ad-hoc, local-only). If omitted "
+                        "and nothing is configured, scans the current repository.")
+    p.add_argument("--path", action="append", default=[], dest="extra_paths", metavar="PATH",
+                   help="additional path to scan (repeatable); same effect as a positional path")
+    p.add_argument("--config", default=None,
+                   help="config file (default: config/security.yml when present)")
     p.add_argument("--local-only", action="store_true", help="skip remote GitHub targets")
     p.add_argument("--fail-on-findings", action="store_true",
                    help="exit non-zero if any infected target (for CI gating)")
@@ -18,7 +24,9 @@ def main() -> None:
                    help="where to write reports (default: reports/security); use a scratch "
                         "dir to avoid touching committed reports")
     a = p.parse_args()
-    sys.exit(service.scan(a.config, a.local_only, a.fail_on_findings, a.reports_dir))
+    paths = [*a.paths, *a.extra_paths]
+    sys.exit(service.scan(a.config, a.local_only, a.fail_on_findings, a.reports_dir,
+                          paths or None))
 
 
 if __name__ == "__main__":

--- a/src/stayawake/bots/security/service.py
+++ b/src/stayawake/bots/security/service.py
@@ -20,6 +20,28 @@ from stayawake.bots.security.models import ScanResult
 from stayawake.bots.security.targets import ScanOptions, LocalRepoTarget, RemoteRepoTarget
 
 REPORTS_DIR = Path("reports/security")
+DEFAULT_CONFIG = "config/security.yml"
+
+
+def _read_config(config_path: str | None) -> dict:
+    """Load the scan config. When `config_path` is None we use the default file if it
+    exists, else an empty config — so a bare `stayawake-security-scan` in any repo
+    works without a config. An explicitly-given path that is missing is an error."""
+    if config_path is None:
+        p = Path(DEFAULT_CONFIG)
+        return load_yaml(p) if p.exists() else {}
+    return load_yaml(config_path)
+
+
+def _enclosing_repo_root(start: Path | None = None) -> Path:
+    """Nearest ancestor of `start` (default: CWD) that contains a .git, else `start`.
+    Lets a bare invocation default to 'scan the repo I'm standing in', even from a
+    subdirectory."""
+    start = (start or Path.cwd()).resolve()
+    for d in (start, *start.parents):
+        if (d / ".git").exists():
+            return d
+    return start
 
 
 def _options(settings: dict) -> ScanOptions:
@@ -94,9 +116,10 @@ def _resolve_remote(cfg: dict, opts: ScanOptions):
     return sorted(set(slugs)), token
 
 
-def scan(config_path: str = "config/security.yml", local_only: bool = False,
-         fail_on_findings: bool = False, reports_dir: str | Path | None = None) -> int:
-    cfg = load_yaml(config_path)
+def scan(config_path: str | None = None, local_only: bool = False,
+         fail_on_findings: bool = False, reports_dir: str | Path | None = None,
+         paths: list[str] | None = None) -> int:
+    cfg = _read_config(config_path)
     settings = cfg.get("settings", {})
     opts = _options(settings)
     sigs = load_signatures(settings.get("signatures_path"))
@@ -105,8 +128,29 @@ def scan(config_path: str = "config/security.yml", local_only: bool = False,
     # so tests and ad-hoc runs never clobber the repo's committed reports.
     rdir = Path(reports_dir or settings.get("reports_dir") or REPORTS_DIR)
 
+    # --- resolve WHAT to scan (targets are orthogonal to auth: local needs no token) --
+    cfg_targets = cfg.get("targets", {}) or {}
+    cfg_local = cfg_targets.get("local", []) or []
+    gh = cfg_targets.get("github", {}) or {}
+    remote_configured = bool(gh.get("users") or gh.get("orgs"))
+
+    cwd_default = False
+    if paths:                                  # explicit ad-hoc paths…
+        local_patterns = list(paths)
+        local_only = True                      # …are a local-only scan (no token needed)
+    elif cfg_local:                            # configured local globs
+        local_patterns = list(cfg_local)
+    elif local_only or not remote_configured:  # bare run → scan the current repo
+        local_patterns = [str(_enclosing_repo_root())]
+        cwd_default = True
+    else:                                       # remote-only config: no CWD fallback
+        local_patterns = []
+
+    if cwd_default:
+        print(f"No targets configured; scanning current repository: {local_patterns[0]}")
+
     results: list[ScanResult] = []
-    for repo in discover_local_repos(cfg.get("targets", {}).get("local", []), opts):
+    for repo in discover_local_repos(local_patterns, opts):
         display = str(repo).replace(os.path.expanduser("~"), "~")
         with LocalRepoTarget(repo, display, opts) as t:
             results.append(scan_target(t, sigs, allowlist))

--- a/tests/bots/security/test_local_targeting.py
+++ b/tests/bots/security/test_local_targeting.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Local-path targeting: explicit paths / CWD default for `stayawake-security-scan`.
+
+Targets (what to scan) are orthogonal to auth (how to access): local scanning needs
+no token. These tests pin the target-resolution precedence and the config/CWD
+fallbacks without running a real (slow, self-flagging) scan — discover_local_repos
+and _resolve_remote are stubbed to capture what they're asked to scan.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from stayawake.bots.security import service as svc
+
+
+class TestTargetResolution(unittest.TestCase):
+    def _capture(self, **scan_kwargs) -> dict:
+        cap: dict = {}
+
+        def fake_discover(patterns, opts):
+            cap["patterns"] = patterns
+            return []
+
+        def fake_remote(cfg, opts):
+            cap["remote_called"] = True
+            return [], None
+
+        with mock.patch.object(svc, "discover_local_repos", side_effect=fake_discover), \
+             mock.patch.object(svc, "_resolve_remote", side_effect=fake_remote):
+            out = Path(tempfile.mkdtemp())
+            svc.scan(reports_dir=str(out), **scan_kwargs)
+        return cap
+
+    def _cfg(self, body: str) -> str:
+        work = Path(tempfile.mkdtemp())
+        cfg = work / "security.yml"
+        cfg.write_text(body, encoding="utf-8")
+        return str(cfg)
+
+    def test_explicit_paths_force_local_only(self):
+        cap = self._capture(config_path=None, paths=["/tmp/a", "/tmp/b"])
+        self.assertEqual(cap["patterns"], ["/tmp/a", "/tmp/b"])
+        self.assertNotIn("remote_called", cap)  # explicit paths ⇒ local-only, no token
+
+    def test_config_local_globs_used(self):
+        cap = self._capture(config_path=self._cfg('settings: {}\ntargets: { local: ["~/dev/**"] }\n'),
+                            local_only=True)
+        self.assertEqual(cap["patterns"], ["~/dev/**"])
+
+    def test_cwd_default_when_nothing_configured(self):
+        cap = self._capture(config_path=self._cfg("settings: {}\ntargets: { local: [] }\n"))
+        self.assertEqual(cap["patterns"], [str(svc._enclosing_repo_root())])
+
+    def test_remote_only_config_has_no_cwd_default(self):
+        cfg = self._cfg("settings: {}\ntargets:\n  local: []\n  github: { users: [octocat] }\n")
+        cap = self._capture(config_path=cfg, local_only=False)
+        self.assertEqual(cap["patterns"], [])        # current repo NOT added to a remote scan
+        self.assertTrue(cap.get("remote_called"))    # remote still enumerated
+
+
+class TestHelpers(unittest.TestCase):
+    def test_enclosing_repo_root_finds_root_from_subdir(self):
+        repo = Path(tempfile.mkdtemp())
+        (repo / ".git").mkdir()
+        sub = repo / "src" / "deep"
+        sub.mkdir(parents=True)
+        self.assertEqual(svc._enclosing_repo_root(sub), repo.resolve())
+
+    def test_enclosing_repo_root_falls_back_to_start(self):
+        plain = Path(tempfile.mkdtemp())  # no .git anywhere under tmp
+        self.assertEqual(svc._enclosing_repo_root(plain), plain.resolve())
+
+    def test_read_config_default_missing_is_empty_but_explicit_missing_raises(self):
+        # explicit but missing path → hard error (don't silently scan nothing)
+        with self.assertRaises(FileNotFoundError):
+            svc._read_config("/no/such/security.yml")
+        # default (None) with no config file present → empty config, no error
+        cwd = os.getcwd()
+        tmp = tempfile.mkdtemp()
+        try:
+            os.chdir(tmp)
+            self.assertEqual(svc._read_config(None), {})
+        finally:
+            os.chdir(cwd)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Scanning local code needs no token and no config (token is only for remote clone / PRs). The scanner now accepts repo/dir paths as positional args or --path, and a bare `stayawake-security-scan` with nothing configured scans the current repository (found by walking up to the nearest .git).

- service.scan() gains a `paths` arg; target precedence: explicit paths (local-only) → config targets.local → CWD repo → remote-only config still scans only remote
- _read_config(): a missing DEFAULT config is now an empty config (bare runs don't crash); an explicitly-passed missing --config is still an error
- _enclosing_repo_root(): resolve the current repo from any subdirectory
- CLI: positional paths + repeatable --path; --config now optional
- tests: target-resolution precedence + helper unit tests
- docs: ad-hoc local scanning section in USAGE; targets.local now optional in CONFIGURATION