### PR TITLE
feat(security): resolve GitHub token via env then gh CLI session

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -84,13 +84,42 @@ stayawake-security-audit                       # advisory; add --fail-on-issues 
 stayawake-security-audit --repo owner/name     # also check that Worm Guard is a required check
 ```
 
-`--repo` needs `GH_SECURITY_TOKEN` (or `GITHUB_TOKEN`) and warns if the default branch
-is unprotected or the Worm Guard status check isn't required.
+`--repo` needs a GitHub credential (an env token or a `gh auth login` session — see
+[Authentication](#authentication)) and warns if the default branch is unprotected or
+the Worm Guard status check isn't required.
 
-## Environment / secrets
+## Authentication
+
+**Local scanning needs no credential** — a GitHub token is only used to clone *private*
+remotes and to write (open PRs / issues, read branch protection). When a token is
+needed, StayAwakeBot resolves one in this order:
+
+1. `GH_SECURITY_TOKEN` or `GITHUB_TOKEN` in the environment (CI and explicit overrides).
+2. Your **GitHub CLI** session — `gh auth token` — short-lived and never stored by
+   StayAwakeBot, which is what the hygiene audit recommends over a cached PAT.
+
+So on a developer machine the simplest setup is `gh auth login` once: nothing to export,
+nothing persisted. If `gh` isn't installed, get it from <https://cli.github.com>
+(StayAwakeBot never installs software for you) or set one of the env vars. A `gh` that is
+missing, logged out, or slow never breaks a run — local scans still work, and remote /
+write operations print exactly what to do.
+
+### Minimal token scopes per command
+
+Grant the least privilege the task needs (fine-grained PAT permission shown; the classic
+scope is in parentheses):
+
+| Command | Needs a token? | Permission (classic) |
+| --- | --- | --- |
+| `stayawake-security-scan <path>` / public remotes | no | — |
+| `stayawake-security-scan` private remotes | read | Contents + Metadata: Read (`repo`) |
+| `stayawake-security-remediate --open-pr` / `--remote` | write | Contents + Pull requests: R/W (`repo`) |
+| `stayawake-security-alert` (GitHub issue) | write | Issues: R/W (`repo` / `public_repo`) |
+| `stayawake-security-audit --repo` | read | Administration: Read (`repo`) |
+
+Other secrets:
 
 - `SLACK_WEBHOOK_URL` — enables Slack alerts (both bots).
-- `GH_SECURITY_TOKEN` (or `GITHUB_TOKEN`) — required for remote scans and opening issues / PRs.
 
 ## In GitHub Actions
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -91,18 +91,28 @@ the Worm Guard status check isn't required.
 ## Authentication
 
 **Local scanning needs no credential** — a GitHub token is only used to clone *private*
-remotes and to write (open PRs / issues, read branch protection). When a token is
-needed, StayAwakeBot resolves one in this order:
+remotes and to write (open PRs / issues, read branch protection).
 
-1. `GH_SECURITY_TOKEN` or `GITHUB_TOKEN` in the environment (CI and explicit overrides).
-2. Your **GitHub CLI** session — `gh auth token` — short-lived and never stored by
+**You only ever configure one token: `GH_SECURITY_TOKEN`.** When a token is needed,
+StayAwakeBot resolves one in this order:
+
+1. **`GH_SECURITY_TOKEN`** — the one token you set up (a PAT). Export it on a dev
+   machine, or add it as a repo secret in CI. This is the only credential you configure,
+   and the only one that can reach **other** repos (the `--remote` org sweep).
+2. **`GITHUB_TOKEN`** — the token GitHub Actions mints automatically for every run. You
+   never set this up: the `GITHUB_` prefix is reserved, so you *can't* even create a
+   secret with that name. It's the zero-config fallback for **same-repo** work inside
+   Actions, and it can't reach other repos.
+3. Your **GitHub CLI** session — `gh auth token` — short-lived and never stored by
    StayAwakeBot, which is what the hygiene audit recommends over a cached PAT.
 
-So on a developer machine the simplest setup is `gh auth login` once: nothing to export,
-nothing persisted. If `gh` isn't installed, get it from <https://cli.github.com>
-(StayAwakeBot never installs software for you) or set one of the env vars. A `gh` that is
-missing, logged out, or slow never breaks a run — local scans still work, and remote /
-write operations print exactly what to do.
+In short: in CI, same-repo jobs ride the automatic `GITHUB_TOKEN` for free and only
+cross-repo work needs the `GH_SECURITY_TOKEN` secret; on a dev machine, the simplest
+setup is `gh auth login` once (nothing to export, nothing persisted), or export
+`GH_SECURITY_TOKEN`. If `gh` isn't installed, get it from <https://cli.github.com>
+(StayAwakeBot never installs software for you). A `gh` that is missing, logged out, or
+slow never breaks a run — local scans still work, and remote / write operations print
+exactly what to do.
 
 ### Minimal token scopes per command
 

--- a/src/stayawake/bots/security/cli/audit.py
+++ b/src/stayawake/bots/security/cli/audit.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import argparse
-import os
 import sys
 
 from stayawake.bots.security import hygiene
+from stayawake.core import auth
 
 
 def main() -> None:
@@ -19,7 +19,10 @@ def main() -> None:
                    help="exit non-zero if any warning-level issue is found")
     a = p.parse_args()
 
-    token = os.environ.get("GH_SECURITY_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    token, _ = auth.resolve_token()
+    if a.repo and not token:
+        print(auth.no_credential_hint("auditing branch protection") +
+              " Skipping the branch-protection check.\n")
     issues = hygiene.check_credentials() + hygiene.check_vscode() \
         + hygiene.check_branch_protection(a.repo, token, a.branch)
     print(hygiene.render(issues))

--- a/src/stayawake/bots/security/cli/remediate.py
+++ b/src/stayawake/bots/security/cli/remediate.py
@@ -9,7 +9,8 @@ Local repos (default — scans config local targets):
 
 Org-wide (configured GitHub targets):
   --remote           clone each configured repo and open/update its dedup'd fix PR
-                     (needs GH_SECURITY_TOKEN / GITHUB_TOKEN with repo + PR write scope)
+                     (needs a GitHub credential with repo + PR write scope: an env
+                     token or a `gh auth login` session)
 
 `python -m security.cli.remediate [--apply] [--open-pr] [--remote]`
 """

--- a/src/stayawake/bots/security/remediator.py
+++ b/src/stayawake/bots/security/remediator.py
@@ -8,7 +8,6 @@ force-push, never pushed. The human reviews and opens the PR.
 """
 from __future__ import annotations
 
-import os
 import shutil
 import subprocess
 import tempfile
@@ -17,6 +16,7 @@ from pathlib import Path
 
 from stayawake.core.config import load_yaml
 from stayawake.core.adapters import github_api
+from stayawake.core import auth
 from stayawake.bots.security.signatures import load_signatures
 from stayawake.bots.security.scanner import scan_target
 from stayawake.bots.security.service import discover_local_repos
@@ -77,7 +77,7 @@ def remediate(config_path: str = "config/security.yml", apply: bool = False,
     opts = _options(settings)
     sigs = load_signatures(settings.get("signatures_path"))
     allowlist = cfg.get("allowlist", [])
-    token = os.environ.get("GH_SECURITY_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    token, _ = auth.resolve_token()
 
     total = 0
     for repo in discover_local_repos(cfg.get("targets", {}).get("local", []), opts):
@@ -98,7 +98,7 @@ def remediate(config_path: str = "config/security.yml", apply: bool = False,
             continue
         if open_pr:
             if not token:
-                print("    → --open-pr needs GH_SECURITY_TOKEN or GITHUB_TOKEN; skipped")
+                print("    → " + auth.no_credential_hint("opening pull requests") + " Skipped.")
             else:
                 print(f"    → {pr_submit.submit_fix_pr(repo, opts, sigs, allowlist, token)}")
         else:
@@ -148,9 +148,11 @@ def submit_org_prs(config_path: str = "config/security.yml", token: str | None =
     opts = _options(settings)
     sigs = load_signatures(settings.get("signatures_path"))
     allowlist = cfg.get("allowlist", [])
-    token = token or os.environ.get("GH_SECURITY_TOKEN") or os.environ.get("GITHUB_TOKEN")
     if not token:
-        print("Org remediation needs GH_SECURITY_TOKEN/GITHUB_TOKEN with repo + PR write scope.")
+        token, _ = auth.resolve_token()
+    if not token:
+        print(auth.no_credential_hint("org remediation PRs") +
+              " The token needs repo + pull-request write scope.")
         return 0
 
     gconf = cfg.get("targets", {}).get("github", {}) or {}

--- a/src/stayawake/bots/security/service.py
+++ b/src/stayawake/bots/security/service.py
@@ -14,6 +14,7 @@ from stayawake.core.config import load_yaml
 from stayawake.core.io import write_json
 from stayawake.core.timeutil import now_iso
 from stayawake.core.adapters import github_api
+from stayawake.core import auth
 from stayawake.bots.security.signatures import load_signatures
 from stayawake.bots.security.scanner import scan_target
 from stayawake.bots.security.models import ScanResult
@@ -84,14 +85,14 @@ def _render_markdown(payload: dict) -> str:
 
 def _resolve_remote(cfg: dict, opts: ScanOptions):
     gconf = cfg.get("targets", {}).get("github", {}) or {}
-    token = os.environ.get("GH_SECURITY_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    token, source = auth.resolve_token()
     slugs: list[str] = []
     for kind in ("users", "orgs"):
         for acct in gconf.get(kind, []) or []:
             slugs += github_api.list_repos(acct, kind, token,
                                            gconf.get("include_forks", False),
                                            gconf.get("include_archived", False))
-    return sorted(set(slugs)), token
+    return sorted(set(slugs)), token, source
 
 
 def scan(config_path: str = "config/security.yml", local_only: bool = False,
@@ -112,7 +113,12 @@ def scan(config_path: str = "config/security.yml", local_only: bool = False,
             results.append(scan_target(t, sigs, allowlist))
 
     if not local_only:
-        slugs, token = _resolve_remote(cfg, opts)
+        slugs, token, source = _resolve_remote(cfg, opts)
+        if slugs and source:
+            print(f"GitHub credential: using {source}.")
+        elif slugs:
+            print("No GitHub credential found; scanning public remotes anonymously. "
+                  "For private repos, run `gh auth login` or set GH_SECURITY_TOKEN.")
         for slug in slugs:
             rt = RemoteRepoTarget(slug, opts, token)
             try:

--- a/src/stayawake/core/auth.py
+++ b/src/stayawake/core/auth.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""GitHub credential resolution.
+
+Preference order (highest first):
+  1. GH_SECURITY_TOKEN / GITHUB_TOKEN in the environment (CI and explicit overrides).
+  2. The user's GitHub CLI session (`gh auth token`) — short-lived and never persisted
+     by us, which is exactly what the hygiene audit recommends over a cached PAT.
+
+Local scanning needs NO credential; this is only for cloning private remotes and for
+writes (PRs, issues, branch-protection reads). Every gh probe degrades gracefully:
+a gh that is missing, not logged in, slow, or erroring never raises — it just yields
+no token, and callers either fall back (anonymous public read) or print an actionable
+hint. Stdlib only. Tokens are returned to callers but never logged here.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+
+ENV_VARS = ("GH_SECURITY_TOKEN", "GITHUB_TOKEN")
+_GH_TIMEOUT = 10  # gh auth token is a local keyring read; should be near-instant.
+
+
+def gh_path() -> str | None:
+    """Absolute path to the GitHub CLI, or None if it isn't installed / on PATH."""
+    return shutil.which("gh")
+
+
+def gh_installed() -> bool:
+    return gh_path() is not None
+
+
+def _env_token() -> tuple[str | None, str | None]:
+    for var in ENV_VARS:
+        val = os.environ.get(var)
+        if val and val.strip():
+            return val.strip(), var
+    return None, None
+
+
+def gh_token(hostname: str = "github.com") -> str | None:
+    """A short-lived token from the gh session, or None. Never raises.
+
+    Handles every edge case: gh not installed, gh present but not logged in (non-zero
+    exit), empty output, a hung gh (timeout), an old gh without --hostname (retry
+    plain), and OS-level spawn errors."""
+    if not gh_installed():
+        return None
+    for argv in (["gh", "auth", "token", "--hostname", hostname], ["gh", "auth", "token"]):
+        try:
+            proc = subprocess.run(argv, capture_output=True, text=True,
+                                  timeout=_GH_TIMEOUT, check=False)
+        except (OSError, subprocess.SubprocessError):
+            return None
+        if proc.returncode == 0:
+            token = (proc.stdout or "").strip()
+            if token:
+                return token
+    return None
+
+
+def resolve_token(hostname: str = "github.com") -> tuple[str | None, str | None]:
+    """Return (token, source). `source` is the env var name, 'gh', or None.
+    Callers decide whether a missing token is fatal (writes) or fine (public read)."""
+    token, source = _env_token()
+    if token:
+        return token, source
+    token = gh_token(hostname)
+    if token:
+        return token, "gh"
+    return None, None
+
+
+def no_credential_hint(action: str = "this operation") -> str:
+    """Actionable, gh-aware guidance to print when a required credential is missing."""
+    env = " / ".join(ENV_VARS)
+    if not gh_installed():
+        return (f"No GitHub credential for {action}. Either install the GitHub CLI "
+                f"(https://cli.github.com) and run `gh auth login`, or set {env} "
+                f"to a token with the required scope.")
+    return (f"No GitHub credential for {action}. Run `gh auth login` "
+            f"(check with `gh auth status`), or set {env} to a token with the required scope.")

--- a/src/stayawake/core/auth.py
+++ b/src/stayawake/core/auth.py
@@ -73,11 +73,14 @@ def resolve_token(hostname: str = "github.com") -> tuple[str | None, str | None]
 
 
 def no_credential_hint(action: str = "this operation") -> str:
-    """Actionable, gh-aware guidance to print when a required credential is missing."""
-    env = " / ".join(ENV_VARS)
+    """Actionable, gh-aware guidance to print when a required credential is missing.
+
+    Names the single token a user configures (GH_SECURITY_TOKEN); the automatic Actions
+    GITHUB_TOKEN isn't something to set up, so we don't tell people to."""
+    var = ENV_VARS[0]  # GH_SECURITY_TOKEN — the one credential a user configures
     if not gh_installed():
         return (f"No GitHub credential for {action}. Either install the GitHub CLI "
-                f"(https://cli.github.com) and run `gh auth login`, or set {env} "
+                f"(https://cli.github.com) and run `gh auth login`, or set {var} "
                 f"to a token with the required scope.")
     return (f"No GitHub credential for {action}. Run `gh auth login` "
-            f"(check with `gh auth status`), or set {env} to a token with the required scope.")
+            f"(check with `gh auth status`), or set {var} to a token with the required scope.")

--- a/tests/bots/security/test_org.py
+++ b/tests/bots/security/test_org.py
@@ -22,7 +22,10 @@ def _cfg(users):
 
 class TestOrgSweep(unittest.TestCase):
     def test_no_token_is_noop(self):
-        with mock.patch.dict("os.environ", {}, clear=True):
+        # No env token AND no gh session → no credential at all (hermetic: don't let a
+        # logged-in gh on the test machine supply a real token).
+        with mock.patch.dict("os.environ", {}, clear=True), \
+             mock.patch.object(remediator.auth, "resolve_token", return_value=(None, None)):
             self.assertEqual(remediator.submit_org_prs(_cfg(["o"]), token=None), 0)
 
     def test_no_targets_is_noop(self):

--- a/tests/core/test_auth.py
+++ b/tests/core/test_auth.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""GitHub credential resolution: env precedence + gh fallback, with every gh edge
+case (not installed, not logged in, empty, timeout, OS error) degrading to no token
+rather than raising."""
+from __future__ import annotations
+
+import os
+import subprocess
+import unittest
+from unittest import mock
+
+from stayawake.core import auth
+
+
+def _cp(returncode: int, stdout: str = "", stderr: str = "") -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=["gh"], returncode=returncode,
+                                       stdout=stdout, stderr=stderr)
+
+
+class TestResolveToken(unittest.TestCase):
+    def test_env_security_token_preferred_and_gh_not_called(self):
+        with mock.patch.dict(os.environ, {"GH_SECURITY_TOKEN": "envtok"}, clear=True), \
+             mock.patch.object(auth, "gh_token", return_value="ghtok") as gh:
+            self.assertEqual(auth.resolve_token(), ("envtok", "GH_SECURITY_TOKEN"))
+            gh.assert_not_called()  # never shell out when an env token is present
+
+    def test_github_token_used_when_security_absent(self):
+        with mock.patch.dict(os.environ, {"GITHUB_TOKEN": "ght"}, clear=True), \
+             mock.patch.object(auth, "gh_token", return_value=None):
+            self.assertEqual(auth.resolve_token(), ("ght", "GITHUB_TOKEN"))
+
+    def test_gh_fallback_when_no_env(self):
+        with mock.patch.dict(os.environ, {}, clear=True), \
+             mock.patch.object(auth, "gh_token", return_value="ghtok"):
+            self.assertEqual(auth.resolve_token(), ("ghtok", "gh"))
+
+    def test_none_when_nothing_available(self):
+        with mock.patch.dict(os.environ, {}, clear=True), \
+             mock.patch.object(auth, "gh_token", return_value=None):
+            self.assertEqual(auth.resolve_token(), (None, None))
+
+    def test_blank_env_var_is_ignored(self):
+        with mock.patch.dict(os.environ, {"GH_SECURITY_TOKEN": "   "}, clear=True), \
+             mock.patch.object(auth, "gh_token", return_value="ghtok"):
+            self.assertEqual(auth.resolve_token(), ("ghtok", "gh"))
+
+
+class TestGhToken(unittest.TestCase):
+    def test_not_installed(self):
+        with mock.patch.object(auth.shutil, "which", return_value=None):
+            self.assertIsNone(auth.gh_token())
+
+    def test_logged_in_returns_stripped_token(self):
+        with mock.patch.object(auth.shutil, "which", return_value="/usr/bin/gh"), \
+             mock.patch.object(auth.subprocess, "run", return_value=_cp(0, "tok123\n")):
+            self.assertEqual(auth.gh_token(), "tok123")
+
+    def test_not_logged_in_returns_none(self):
+        with mock.patch.object(auth.shutil, "which", return_value="/usr/bin/gh"), \
+             mock.patch.object(auth.subprocess, "run", return_value=_cp(1, "", "no oauth token")):
+            self.assertIsNone(auth.gh_token())
+
+    def test_empty_output_returns_none(self):
+        with mock.patch.object(auth.shutil, "which", return_value="/usr/bin/gh"), \
+             mock.patch.object(auth.subprocess, "run", return_value=_cp(0, "  \n")):
+            self.assertIsNone(auth.gh_token())
+
+    def test_timeout_returns_none(self):
+        with mock.patch.object(auth.shutil, "which", return_value="/usr/bin/gh"), \
+             mock.patch.object(auth.subprocess, "run",
+                               side_effect=subprocess.TimeoutExpired("gh", 10)):
+            self.assertIsNone(auth.gh_token())
+
+    def test_os_error_returns_none(self):
+        with mock.patch.object(auth.shutil, "which", return_value="/usr/bin/gh"), \
+             mock.patch.object(auth.subprocess, "run", side_effect=OSError("spawn failed")):
+            self.assertIsNone(auth.gh_token())
+
+
+class TestHint(unittest.TestCase):
+    def test_hint_when_gh_missing_says_install(self):
+        with mock.patch.object(auth, "gh_installed", return_value=False):
+            h = auth.no_credential_hint("cloning private repos")
+            self.assertIn("install the github cli", h.lower())
+            self.assertIn("cloning private repos", h)
+
+    def test_hint_when_gh_present_says_login(self):
+        with mock.patch.object(auth, "gh_installed", return_value=True):
+            h = auth.no_credential_hint("cloning private repos")
+            self.assertIn("gh auth login", h)
+            self.assertNotIn("install the GitHub CLI", h)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds core/auth.py as the single credential resolver: GH_SECURITY_TOKEN / GITHUB_TOKEN first (CI, explicit overrides), then the user's short-lived `gh auth token` session — never persisted, matching the hygiene doctrine. Local scanning still needs no token.

gh is fully edge-cased: not installed, not logged in, empty output, timeout, old gh without --hostname, and OS spawn errors all degrade to "no token" without raising. We never auto-install gh; instead callers print an actionable, gh-aware hint.

- service._resolve_remote / scan(): use auth.resolve_token; print credential provenance, or fall back to anonymous public-remote scanning with guidance
- remediator.remediate / submit_org_prs: resolve via auth; clearer no-credential hints
- cli/audit --repo: resolve via auth; warn + skip branch-protection cleanly when absent
- tests: 13 auth tests covering env precedence + every gh failure mode; org test made hermetic against a logged-in gh on the test machine
- docs: Authentication section (resolution order + minimal token scopes per command)