### PR TITLE
feat(security): patch-file fallback when a fix branch can't be pushed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -208,6 +208,7 @@ __marimo__/
 # Malware quarantine / remediation artifacts (kept local, never committed)
 .malware-quarantine/
 *.malware-bak
+sab-patches/
 
 .DS_Store
 

--- a/config/security.yml
+++ b/config/security.yml
@@ -6,7 +6,7 @@
 
 settings:
   # Directories never traversed during scanning.
-  exclude_dirs: [".git", "node_modules", ".next", "dist", "build", ".malware-quarantine", "reports", ".venv", "venv"]
+  exclude_dirs: [".git", "node_modules", ".next", "dist", "build", ".malware-quarantine", "reports", "sab-patches", ".venv", "venv"]
   # Max file size (bytes) to read for content matching. Source files larger than this
   # are still scanned head+tail; only non-source assets are skipped.
   max_file_bytes: 2000000

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -62,6 +62,11 @@ stayawake-security-remediate --apply --open-pr  # also open one rolling PR per r
 stayawake-security-remediate --remote           # operate on remote GitHub targets from config
 ```
 
+**Read-only fallback:** when `--open-pr` / `--remote` can't push a fix branch (you only
+have read access to the target), StayAwakeBot doesn't discard the fix — it writes it as a
+`git am`-able patch under `sab-patches/` and tells you how to apply it. So remediation
+always produces something actionable, even without write access.
+
 Drop `--local-only` to also scan the GitHub users/orgs listed in `config/security.yml`.
 Use `--fail-on-findings` to make `scan` exit non-zero (the CI gate uses this).
 See [SECURITY_ARCHITECTURE.md](SECURITY_ARCHITECTURE.md) for how detection / remediation work.

--- a/src/stayawake/bots/security/pr.py
+++ b/src/stayawake/bots/security/pr.py
@@ -22,6 +22,7 @@ from stayawake.bots.security.models import QUARANTINE_DIR
 from stayawake.bots.security import remediation
 
 FIX_BRANCH = "security/auto-clean"
+PATCHES_DIR = Path("sab-patches")   # where the read-only fallback writes .patch files
 _BOT = ("-c", "user.name=StayAwakeBot Security", "-c", "user.email=security-bot@stayawake.local")
 
 
@@ -35,6 +36,22 @@ def _untrack_quarantine(repo: Path) -> bool:
     quarantine dir before staging. Returns True if the quarantine is clean after."""
     _git(repo, "rm", "-r", "--cached", "--ignore-unmatch", QUARANTINE_DIR)
     return not _git(repo, "ls-files", QUARANTINE_DIR).stdout.strip()
+
+
+def _save_patch(wt: Path, slug: str, out_dir: Path) -> Path | None:
+    """Capture the fix commit as a git-am-able patch so a read-only run (no write access)
+    never loses the work when the branch can't be pushed. Returns the path, or None on
+    failure. This is the no-write floor of the remediation ladder."""
+    r = _git(wt, "format-patch", "-1", "HEAD", "--stdout")
+    if r.returncode != 0 or not r.stdout.strip():
+        return None
+    try:
+        out_dir.mkdir(parents=True, exist_ok=True)
+        dest = (out_dir / (slug.replace("/", "-") + ".patch")).resolve()
+        dest.write_text(r.stdout, encoding="utf-8")
+    except OSError:
+        return None
+    return dest
 
 
 def slug_from_url(url: str) -> str | None:
@@ -64,8 +81,11 @@ def _pr_body(slug: str, changes) -> str:
     return "\n".join(lines)
 
 
-def submit_fix_pr(repo: Path, opts, signatures, allowlist, token: str) -> str:
-    """Open (or update) one dedup'd remediation PR for `repo`. Returns an outcome string."""
+def submit_fix_pr(repo: Path, opts, signatures, allowlist, token: str,
+                  patches_dir: Path | None = None) -> str:
+    """Open (or update) one dedup'd remediation PR for `repo`. Returns an outcome string.
+    If the branch can't be pushed (read-only access), falls back to writing a patch file
+    instead of discarding the fix when the worktree is torn down."""
     slug = origin_slug(repo)
     if not slug:
         return "no GitHub origin remote — skipped"
@@ -116,6 +136,13 @@ def submit_fix_pr(repo: Path, opts, signatures, allowlist, token: str) -> str:
 
         push_url = f"https://x-access-token:{token}@github.com/{slug}.git"
         if _git(wt, "push", "--force", push_url, f"{FIX_BRANCH}:{FIX_BRANCH}").returncode != 0:
+            # No write access: don't lose the fix when the worktree is removed — save it
+            # as a patch the repo owner can apply themselves.
+            patch = _save_patch(wt, slug, Path(patches_dir) if patches_dir else PATCHES_DIR)
+            if patch:
+                return (f"{slug}: push rejected (no write access?) — saved the fix as a patch at "
+                        f"{patch}. Apply on '{base}' with `git am {patch.name}`, or re-run with a "
+                        f"token that has repo + PR write scope.")
             return f"{slug}: branch push failed (check token write scope)"
 
         if existing:

--- a/src/stayawake/bots/security/targets/base.py
+++ b/src/stayawake/bots/security/targets/base.py
@@ -30,10 +30,12 @@ def _ext(rel: str) -> str:
 
 @dataclass
 class ScanOptions:
-    # "reports" is excluded so the scanner never re-flags its OWN output: a report
-    # quotes the evidence of a detected payload, so scanning it would self-trigger.
+    # "reports" and "sab-patches" are excluded so the scanner never re-flags its OWN
+    # output: a report quotes a detected payload's evidence and a remediation patch
+    # contains the removed payload lines as diff deletions — scanning either self-triggers.
     exclude_dirs: set[str] = field(default_factory=lambda: {
-        ".git", "node_modules", ".next", "dist", "build", ".malware-quarantine", "reports"})
+        ".git", "node_modules", ".next", "dist", "build", ".malware-quarantine",
+        "reports", "sab-patches"})
     max_file_bytes: int = 2_000_000
     remote_clone_depth: int = 50
 

--- a/tests/bots/security/test_pr.py
+++ b/tests/bots/security/test_pr.py
@@ -2,6 +2,7 @@
 """PR submission: slug parsing + duplicate-PR avoidance (no real git/network)."""
 from __future__ import annotations
 
+import tempfile
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
@@ -76,6 +77,48 @@ class TestNoDuplicatePr(unittest.TestCase):
             outcome = pr.submit_fix_pr(Path("/repo"), object(), {}, [], token="t")
         create.assert_not_called()
         self.assertIn("ABORTED", outcome)
+
+
+class TestPatchFallback(unittest.TestCase):
+    def test_push_failure_saves_patch_instead_of_losing_fix(self):
+        # No write access: the branch push fails, so the fix must be written as a patch
+        # (the no-write floor of the remediation ladder), not silently discarded.
+        out = Path(tempfile.mkdtemp())
+        finding = Finding("x", "code-loader", Severity.CRITICAL, "postcss.config.mjs",
+                          "loader", remediation="strip-appended-payload")
+        scans = [ScanResult("owner/repo", "local", [finding]),   # worktree scan: infected
+                 ScanResult("owner/repo", "local", []),          # post-apply re-scan: clean
+                 ScanResult("owner/repo", "local", [])]
+
+        def fake_git(cwd, *args):
+            cp = SimpleNamespace(returncode=0, stdout="", stderr="")
+            if args[:2] == ("remote", "get-url"):
+                cp.stdout = "git@github.com:owner/repo.git"
+            elif args[:1] == ("symbolic-ref",):
+                cp.stdout = "refs/remotes/origin/main"
+            elif args[:1] == ("push",):
+                cp.returncode = 1                       # <-- read-only: push rejected
+            elif args[:1] == ("format-patch",):
+                cp.stdout = "From abc\nSubject: fix\n\npatch-body\n"
+            return cp
+
+        with mock.patch.object(pr, "_git", side_effect=fake_git), \
+             mock.patch.object(pr, "scan_target",
+                               side_effect=lambda *a, **k: scans.pop(0) if scans else scans), \
+             mock.patch.object(pr.remediation, "plan",
+                               return_value=[Change("strip-payload", "postcss.config.mjs")]), \
+             mock.patch.object(pr.remediation, "apply",
+                               return_value=[Change("strip-payload", "postcss.config.mjs")]), \
+             mock.patch.object(pr.github_api, "list_open_pulls", return_value=[]), \
+             mock.patch.object(pr.github_api, "create_pull") as create:
+            outcome = pr.submit_fix_pr(Path("/repo"), object(), {}, [], token="t",
+                                       patches_dir=out)
+
+        create.assert_not_called()                       # no PR opened
+        self.assertIn("patch", outcome.lower())
+        patch_file = out / "owner-repo.patch"
+        self.assertTrue(patch_file.is_file(), "fix must be saved as a patch on push failure")
+        self.assertIn("patch-body", patch_file.read_text(encoding="utf-8"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The no-write floor of the remediation ladder: when submit_fix_pr can't push the security/auto-clean branch (read-only access to the target), it no longer discards the fix as the worktree is torn down — it writes the fix commit as a git am-able patch under sab-patches/ and reports how to apply it. Remediation now always yields something actionable, even with no write access.

- pr._save_patch + push-failure fallback; submit_fix_pr gains optional patches_dir
- exclude sab-patches/ from scanning (a patch embeds removed payload lines as diff deletions, so scanning it would self-flag — same class as the reports/ exclusion) in ScanOptions defaults and config/security.yml; gitignore sab-patches/
- test: push failure writes the patch instead of losing the fix; opens no PR