### PR TITLE
feat(action): publish worm-scan to the GitHub Marketplace (P2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project are documented here. The format is based on
 ## [Unreleased]
 
 ### Added
+- **GitHub Action Marketplace entry point** (`action.yml` at repo root): adopt the security
+  sentinel with `uses: Ndevu12/stayAwakeBot@v1`. It wraps the existing
+  `.github/actions/worm-scan` composite (still reachable at its subpath), so no scan logic is
+  duplicated and the original interface keeps working. Includes Marketplace `branding`.
 - Versioned-release pipeline (`.github/workflows/release.yml`): tag-triggered build →
   self-scan gate → PyPI publish via Trusted Publishing (OIDC, no stored token) with PEP 740
   attestations → GitHub Release. Manual `workflow_dispatch` path publishes to TestPyPI.
@@ -22,6 +26,8 @@ All notable changes to this project are documented here. The format is based on
   `pyproject.toml`.
 - The source distribution (sdist) is now an explicit allowlist (`src/`, README, LICENSE,
   CHANGELOG, pyproject) so it no longer ships `reports/`, `.github/`, or local config.
+- `hatch-vcs` now derives the version only from `vX.Y.Z` tags (`git_describe_command` match),
+  so the moving Marketplace major tag (`v1`) cannot be mistaken for the package version.
 
 ## [0.1.0] - Unreleased
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,26 @@ stayawake-security-scan --config config/security.yml --local-only   # worm scan
 > The distribution is published as **`stayawakebot`** (the name `stayawake` is taken on
 > PyPI by an unrelated project); the import package and `stayawake-*` commands are unchanged.
 
+## Gate any repo's CI (GitHub Action)
+
+Add the security sentinel to any repository in one step — no install, no clone:
+
+```yaml
+# .github/workflows/worm-guard.yml
+on: [pull_request, push]
+jobs:
+  worm-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }   # full history so evil merges are detectable
+      - uses: Ndevu12/stayAwakeBot@v1      # pin to a SHA in production
+        with:
+          fail-on-findings: 'true'
+```
+
+Pin `@<sha>` rather than `@v1` for tamper-evident runs. See [Security baseline](prevent/SECURITY_BASELINE.md).
+
 ## Documentation
 
 - [Usage](docs/USAGE.md) — install, run both bots, secrets, GitHub Actions, deploy your own

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,46 @@
+# Root action.yml — the GitHub Marketplace entry point.
+#
+# Marketplace requires the action metadata at the repository ROOT, so this file lets any
+# repo adopt the security sentinel with `uses: Ndevu12/stayAwakeBot@v1`. It is a thin
+# wrapper that delegates to the proven composite action at `.github/actions/worm-scan`
+# (still referenced internally by worm-guard.yml and externally via the documented subpath
+# `Ndevu12/stayAwakeBot/.github/actions/worm-scan@<sha>` — both kept working). One
+# implementation, two entry points; no logic is duplicated here.
+name: 'StayAwakeBot Worm Scan'
+description: >-
+  Scan a checked-out repository for self-propagating supply-chain worm indicators
+  (obfuscated loaders, fake fonts, VS Code auto-run tasks, evil merges) and fail CI on findings.
+author: 'Ndevu12'
+
+branding:
+  icon: 'shield'
+  color: 'red'
+
+inputs:
+  sentinel-ref:
+    description: >-
+      Ref/SHA of Ndevu12/stayAwakeBot to install the scanner from. Defaults to `main` so a
+      one-line adoption always pulls the newest worm signatures (antivirus-style). Pin to a
+      SHA or release tag for reproducible, tamper-evident runs (recommended in production).
+    required: false
+    default: 'main'
+  fail-on-findings:
+    description: 'Fail the job when indicators are found.'
+    required: false
+    default: 'true'
+  allowlist-globs:
+    description: >-
+      Comma-separated allowlist entries of the form `path_glob|signature_id` (a bare path
+      glob is ignored, so a fresh payload under an allowlisted path is still flagged).
+    required: false
+    default: ''
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Worm scan
+      uses: ./.github/actions/worm-scan
+      with:
+        sentinel-ref: ${{ inputs.sentinel-ref }}
+        fail-on-findings: ${{ inputs.fail-on-findings }}
+        allowlist-globs: ${{ inputs.allowlist-globs }}

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -84,6 +84,43 @@ the OIDC exchange is rejected.
   ```
 - `pip download stayawakebot==<version>` then `twine check` the artifacts.
 
+## Publishing the Action to the Marketplace (P2)
+
+The scanner is also a GitHub Action. The Marketplace entry point is the **root `action.yml`**
+(a thin wrapper over `.github/actions/worm-scan`); Marketplace requires the metadata at the
+repo root. This is a one-time listing plus a moving-tag convention.
+
+### One-time listing
+1. Ensure the root `action.yml` has a unique `name`, a `description`, and `branding`
+   (icon + color) — it does. Marketplace action names are globally unique; if
+   `StayAwakeBot Worm Scan` is taken, adjust the `name` field.
+2. GitHub → repo → **Releases → Draft a new release** → tick **"Publish this Action to the
+   GitHub Marketplace"**, accept the agreement, pick a primary + secondary category
+   (Security / Continuous integration).
+3. Publish the release (see tag convention below).
+
+### Tag convention — two schemes share one namespace
+- **Package (PyPI):** full `vX.Y.Z` tags. These are the source of truth for the version
+  (`hatch-vcs`).
+- **Action (Marketplace):** consumers expect a **moving major** tag, `uses: …@v1`. After each
+  `vX.Y.Z` release, fast-forward the major tag:
+  ```bash
+  git tag -f v1 vX.Y.Z      # move v1 to the new release
+  git push -f origin v1
+  ```
+- These do **not** collide: `hatch-vcs` is pinned (`pyproject.toml` →
+  `tool.hatch.version.raw-options.git_describe_command`) to match only `v[0-9]*.[0-9]*.[0-9]*`,
+  so a bare `v1` can never be mistaken for the package version. (Verified: with a `v1` tag
+  present, `git describe` still resolves to the latest `vX.Y.Z`.)
+- Keep recommending **SHA pins** (`@<sha>`) in docs for production consumers; the moving `v1`
+  is for convenience, not for tamper-evidence.
+
+### Scanner-version coupling (post-PyPI follow-up)
+The Action currently installs the scanner from git (`sentinel-ref`, default `main`). Once the
+package is on PyPI, switch the install step in `.github/actions/worm-scan/action.yml` to
+`pip install "stayawakebot==<version>"` so the gate runs a pinned, attested release instead of
+a mutable ref — and bump that version in lockstep with the moving `v1` tag.
+
 ## Notes & invariants
 
 - **Versioning:** `hatch-vcs` derives the version from the tag — never hand-edit a version.

--- a/docs/SECURITY_ARCHITECTURE.md
+++ b/docs/SECURITY_ARCHITECTURE.md
@@ -90,7 +90,9 @@ protected and the **Worm Guard** check is required.
 
 ## Prevention
 
-A reusable `worm-scan` composite Action (`.github/actions/worm-scan`) gates PRs/merges in
+A reusable `worm-scan` composite Action — published to the GitHub Marketplace via the root
+`action.yml` (`uses: Ndevu12/stayAwakeBot@v1`) and also reachable at its original subpath
+`.github/actions/worm-scan` — gates PRs/merges in
 any repo (`worm-guard.yml`), portable git hooks (`prevent/hooks/`) block local commits and
 catch incoming infections, and `prevent/SECURITY_BASELINE.md` covers branch protection +
 token/Action hardening. The Action installs the published scanner

--- a/prevent/SECURITY_BASELINE.md
+++ b/prevent/SECURITY_BASELINE.md
@@ -27,6 +27,10 @@ jobs:
 ```
 **Pin `@<SHA>`**, not `@main`, so a compromise of the action repo can't change what runs.
 
+The same scanner is published to the GitHub Marketplace, so the shorter root reference also
+works — `uses: Ndevu12/stayAwakeBot@v1` (or `@<SHA>`). Both forms run identical logic; the
+root form is the Marketplace entry point, the subpath form is the original interface.
+
 ## 2. Local git hooks (defense-in-depth on the developer machine)
 The hooks are dependency-free (grep only) and cover both directions:
 - **`pre-commit`** — blocks *committing* loader fingerprints (incl. the `global[...]` bang/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,13 @@ stayawake-security-audit   = "stayawake.bots.security.cli.audit:main"
 [tool.hatch.version]
 source = "vcs"
 
+# Only consider full X.Y.Z release tags when deriving the version. The action is published
+# to the Marketplace under MOVING major tags (`v1`, `v2`) that share this git tag namespace;
+# without this `--match`, `git describe` could latch onto a bare `v1` and report the package
+# as version 1.x. Restricting the match keeps the two tag schemes from colliding.
+[tool.hatch.version.raw-options]
+git_describe_command = ["git", "describe", "--dirty", "--tags", "--long", "--match", "v[0-9]*.[0-9]*.[0-9]*"]
+
 # Keep the source distribution lean and safe. Hatchling's default sdist would ship the
 # whole working tree — including reports/ (hundreds of scan reports that QUOTE detected
 # malware payloads) and tests/ fixtures (deliberately "infected" sample files). Shipping


### PR DESCRIPTION
## What & why (P2 — distribution strategy)

Makes the supply-chain **worm-scan** action installable from the GitHub Marketplace, so any
repo can adopt the security sentinel with one line:

```yaml
- uses: Ndevu12/stayAwakeBot@v1      # pin to a SHA in production
  with: { fail-on-findings: 'true' }
```

## Changes

- **`action.yml` at repo root** — the Marketplace entry point (Marketplace requires the
  metadata at the repository root). It is a **thin composite wrapper** over the existing
  `.github/actions/worm-scan` action, which stays reachable at its documented subpath
  (`Ndevu12/stayAwakeBot/.github/actions/worm-scan@<sha>`, per `SECURITY_BASELINE.md`). One
  implementation, two entry points — **no scan logic duplicated**. Adds Marketplace
  `branding` (shield / red).
- **hatch-vcs hardened** — the moving Marketplace major tag (`v1`) and the package's `vX.Y.Z`
  tags share one git tag namespace. Constrained version derivation to
  `git describe --match 'v[0-9]*.[0-9]*.[0-9]*'` so a bare `v1` can't make the package report
  itself as `1.x`. **Verified:** with a `v1` tag present, describe still resolves to `v0.1.0`
  and the build produced `stayawakebot-0.1.1.dev…`, not `1.x`.
- **Docs** — README "Gate any repo's CI" snippet; `RELEASING.md` gains the Marketplace publish
  flow, the dual-tag strategy, and the post-PyPI scanner-pinning follow-up;
  `SECURITY_BASELINE.md` / `SECURITY_ARCHITECTURE.md` note the root reference. CHANGELOG updated.

## Design notes (surfaced, not hidden)

- **Root action vs companion repo:** went root-level (the recommendation; a companion repo is
  also out of scope for the current tooling). Reversible later if the action's release cadence
  diverges from the package's.
- **`sentinel-ref` defaults to `main`** for one-line adoption (newest signatures,
  antivirus-style), with SHA-pinning documented for production. The ideal end state —
  installing a pinned `stayawakebot==<version>` from PyPI — is a documented follow-up that
  activates once P1 actually publishes.

## Manual steps remaining (maintainer)

Documented in `docs/RELEASING.md`: the actual Marketplace listing ("Draft a release → Publish
this Action to the Marketplace") and fast-forwarding the `v1` tag per release.

## Merge order

⚠️ **Stacked on #1003 (P0/P1).** Base is `claude/distribution-p0-p1` so this diff shows P2
only. Merge #1003 first; GitHub will then auto-retarget this PR to `main`.

## Validation

- `action.yml` parses; `name` / `branding` / `inputs` correct.
- hatch-vcs `--match` proven to ignore a bare `v1` tag (build still derived from `v0.1.0`).
- No real worm-signature payloads introduced (added lines checked against the content matchers).

---