### PR TITLE
feat(security): pass GitHub token via GIT_ASKPASS, never in URL/argv

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -113,7 +113,9 @@ the Worm Guard status check isn't required.
 ## Authentication
 
 **Local scanning needs no credential** — a GitHub token is only used to clone *private*
-remotes and to write (open PRs / issues, read branch protection).
+remotes and to write (open PRs / issues, read branch protection). However it's supplied,
+the token is handed to git via `GIT_ASKPASS` — never embedded in a clone/push URL or the
+process arguments, so it can't leak through `ps`, git's error output, or CI logs.
 
 **You only ever configure one token: `GH_SECURITY_TOKEN`.** When a token is needed,
 StayAwakeBot resolves one in this order:

--- a/src/stayawake/bots/security/pr.py
+++ b/src/stayawake/bots/security/pr.py
@@ -16,6 +16,7 @@ import tempfile
 from pathlib import Path
 
 from stayawake.core.adapters import github_api
+from stayawake.core import git as gitutil
 from stayawake.bots.security.scanner import scan_target
 from stayawake.bots.security.targets import LocalRepoTarget
 from stayawake.bots.security.models import QUARANTINE_DIR
@@ -26,9 +27,9 @@ PATCHES_DIR = Path("sab-patches")   # where the read-only fallback writes .patch
 _BOT = ("-c", "user.name=StayAwakeBot Security", "-c", "user.email=security-bot@stayawake.local")
 
 
-def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess:
+def _git(cwd: Path, *args: str, env: dict | None = None) -> subprocess.CompletedProcess:
     return subprocess.run(["git", "-C", str(cwd), *args],
-                          capture_output=True, text=True, check=False)
+                          capture_output=True, text=True, check=False, env=env)
 
 
 def _untrack_quarantine(repo: Path) -> bool:
@@ -134,8 +135,11 @@ def submit_fix_pr(repo: Path, opts, signatures, allowlist, token: str,
               "\n".join(f"- {c.action}: {c.path}" for c in applied)
         _git(wt, *_BOT, "commit", "-m", msg)
 
-        push_url = f"https://x-access-token:{token}@github.com/{slug}.git"
-        if _git(wt, "push", "--force", push_url, f"{FIX_BRANCH}:{FIX_BRANCH}").returncode != 0:
+        # Token is passed via GIT_ASKPASS (env), never embedded in the push URL/argv.
+        with gitutil.github_https_auth(token) as (prefix, env):
+            pushed = _git(wt, "push", "--force", f"{prefix}{slug}.git",
+                          f"{FIX_BRANCH}:{FIX_BRANCH}", env=env).returncode == 0
+        if not pushed:
             # No write access: don't lose the fix when the worktree is removed — save it
             # as a patch the repo owner can apply themselves.
             patch = _save_patch(wt, slug, Path(patches_dir) if patches_dir else PATCHES_DIR)

--- a/src/stayawake/bots/security/remediator.py
+++ b/src/stayawake/bots/security/remediator.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from stayawake.core.config import load_yaml
 from stayawake.core.adapters import github_api
 from stayawake.core import auth
+from stayawake.core import git as gitutil
 from stayawake.bots.security.signatures import load_signatures
 from stayawake.bots.security.scanner import scan_target
 from stayawake.bots.security.service import discover_local_repos
@@ -172,9 +173,11 @@ def submit_org_prs(config_path: str = "config/security.yml", token: str | None =
     for slug in slugs:
         tmp = Path(tempfile.mkdtemp(prefix="sab-org-"))
         clone = tmp / "repo"
-        url = f"https://x-access-token:{token}@github.com/{slug}.git"
-        r = subprocess.run(["git", "clone", "--quiet", "--depth", "50", url, str(clone)],
-                           capture_output=True, text=True, check=False)
+        # Token via GIT_ASKPASS (env), never in the clone URL/argv.
+        with gitutil.github_https_auth(token) as (prefix, env):
+            r = subprocess.run(["git", "clone", "--quiet", "--depth", "50",
+                                f"{prefix}{slug}.git", str(clone)],
+                               capture_output=True, text=True, check=False, env=env)
         if r.returncode != 0:
             print(f"  {slug}: clone failed (check token access)")
             shutil.rmtree(tmp, ignore_errors=True)

--- a/src/stayawake/bots/security/targets/remote.py
+++ b/src/stayawake/bots/security/targets/remote.py
@@ -5,12 +5,12 @@ Never installs, builds, runs hooks, or opens an editor — clone-and-read only.
 """
 from __future__ import annotations
 
-import os
 import shutil
 import subprocess
 import tempfile
 from pathlib import Path
 
+from stayawake.core import git as gitutil
 from stayawake.bots.security.targets.base import Target, ScanOptions
 
 
@@ -24,15 +24,14 @@ class RemoteRepoTarget(Target):
         self._token = token
 
     def clone(self) -> bool:
-        url = f"https://github.com/{self._slug}.git"
-        env = dict(os.environ, GIT_TERMINAL_PROMPT="0", GIT_EDITOR="true")
-        if self._token:
-            url = f"https://x-access-token:{self._token}@github.com/{self._slug}.git"
+        # Token (if any) is supplied via GIT_ASKPASS, never in the URL/argv.
         try:
-            r = subprocess.run(
-                ["git", "clone", "--depth", str(self.opts.remote_clone_depth), "--no-tags",
-                 "--config", "core.hooksPath=/dev/null", url, str(self.root)],
-                capture_output=True, text=True, timeout=300, env=env, check=False)
+            with gitutil.github_https_auth(self._token) as (prefix, env):
+                r = subprocess.run(
+                    ["git", "clone", "--depth", str(self.opts.remote_clone_depth), "--no-tags",
+                     "--config", "core.hooksPath=/dev/null",
+                     f"{prefix}{self._slug}.git", str(self.root)],
+                    capture_output=True, text=True, timeout=300, env=env, check=False)
             return r.returncode == 0
         except (subprocess.SubprocessError, OSError):
             return False

--- a/src/stayawake/core/git.py
+++ b/src/stayawake/core/git.py
@@ -6,8 +6,52 @@ without ever executing repository code. Used mainly by the evil-merge detector.
 """
 from __future__ import annotations
 
+import contextlib
+import os
+import stat
 import subprocess
+import tempfile
 from pathlib import Path
+
+_HOST = "github.com"
+
+
+@contextlib.contextmanager
+def github_https_auth(token: str | None):
+    """Yield (url_prefix, env) for authenticated GitHub HTTPS that keeps the token OUT of
+    the URL and process args — so it can't leak via argv, `ps`, git's own error output,
+    or anything we might log.
+
+    With a token (POSIX), GIT_ASKPASS points at a throwaway 0700 script that reads the
+    token from the child env, and the URL prefix carries only the username
+    (`https://x-access-token@github.com/`). The secret therefore lives only in the child
+    environment, never in argv/URLs/files. On Windows (no POSIX askpass) and when there
+    is no token, it falls back to the prior behaviour.
+
+        with github_https_auth(token) as (prefix, env):
+            subprocess.run(["git", "clone", f"{prefix}{slug}.git", dst], env=env, ...)
+    """
+    base_env = dict(os.environ, GIT_TERMINAL_PROMPT="0", GIT_EDITOR="true")
+    if not token:
+        yield f"https://{_HOST}/", base_env
+        return
+    if os.name == "nt":  # no /bin/sh askpass on native Windows — keep credential-in-URL
+        yield f"https://x-access-token:{token}@{_HOST}/", base_env
+        return
+    fd, path = tempfile.mkstemp(prefix="sab-askpass-")
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write("#!/bin/sh\n"
+                    'case "$1" in\n'
+                    "  Username*) printf %s 'x-access-token' ;;\n"
+                    '  *) printf %s "$SAB_GH_TOKEN" ;;\n'
+                    "esac\n")
+        os.chmod(path, stat.S_IRWXU)  # 0700: only this user can read/exec the helper
+        env = dict(base_env, GIT_ASKPASS=path, SAB_GH_TOKEN=token)
+        yield f"https://x-access-token@{_HOST}/", env
+    finally:
+        with contextlib.suppress(OSError):
+            os.unlink(path)
 
 
 def _run(repo: str | Path, args: list[str]) -> str:

--- a/tests/bots/security/test_pr.py
+++ b/tests/bots/security/test_pr.py
@@ -21,7 +21,7 @@ class TestSlug(unittest.TestCase):
         self.assertIsNone(pr.slug_from_url("git@gitlab.com:x/y.git"))
 
 
-def _fake_git(cwd, *args):
+def _fake_git(cwd, *args, **kwargs):   # **kwargs tolerates _git(..., env=…) on push
     cp = SimpleNamespace(returncode=0, stdout="", stderr="")
     if args[:2] == ("remote", "get-url"):
         cp.stdout = "git@github.com:owner/repo.git"
@@ -90,7 +90,7 @@ class TestPatchFallback(unittest.TestCase):
                  ScanResult("owner/repo", "local", []),          # post-apply re-scan: clean
                  ScanResult("owner/repo", "local", [])]
 
-        def fake_git(cwd, *args):
+        def fake_git(cwd, *args, **kwargs):   # **kwargs tolerates _git(..., env=…) on push
             cp = SimpleNamespace(returncode=0, stdout="", stderr="")
             if args[:2] == ("remote", "get-url"):
                 cp.stdout = "git@github.com:owner/repo.git"

--- a/tests/core/test_git_auth.py
+++ b/tests/core/test_git_auth.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""GitHub HTTPS auth helper: the token must never appear in the URL, process args, or
+the askpass file — only in the child environment, where git reads it via GIT_ASKPASS."""
+from __future__ import annotations
+
+import os
+import unittest
+from pathlib import Path
+
+from stayawake.core import git as gitutil
+
+
+@unittest.skipIf(os.name == "nt", "askpass path is POSIX-only; Windows keeps credential-in-URL")
+class TestGithubHttpsAuth(unittest.TestCase):
+    def test_token_kept_out_of_url_and_askpass_file(self):
+        secret = "ghp_SUPERSECRET_0123456789"
+        with gitutil.github_https_auth(secret) as (prefix, env):
+            # URL prefix carries only the username, never the secret.
+            self.assertEqual(prefix, "https://x-access-token@github.com/")
+            self.assertNotIn(secret, prefix)
+            # The secret lives only in the child env, read via the askpass helper.
+            self.assertEqual(env["SAB_GH_TOKEN"], secret)
+            self.assertEqual(env["GIT_TERMINAL_PROMPT"], "0")
+            askpass = Path(env["GIT_ASKPASS"])
+            self.assertTrue(askpass.is_file())
+            self.assertTrue(os.access(askpass, os.X_OK), "askpass must be executable")
+            self.assertNotIn(secret, askpass.read_text(encoding="utf-8"),
+                             "token must NOT be baked into the askpass script")
+            saved = askpass
+        self.assertFalse(saved.exists(), "askpass script must be cleaned up on exit")
+
+    def test_no_token_is_anonymous(self):
+        with gitutil.github_https_auth(None) as (prefix, env):
+            self.assertEqual(prefix, "https://github.com/")
+            self.assertNotIn("GIT_ASKPASS", env)
+            self.assertEqual(env["GIT_TERMINAL_PROMPT"], "0")
+
+    def test_empty_token_is_anonymous(self):
+        with gitutil.github_https_auth("") as (prefix, env):
+            self.assertEqual(prefix, "https://github.com/")
+            self.assertNotIn("GIT_ASKPASS", env)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A security tool shouldn't leak the very credential it warns about. The token was embedded in clone/push URLs, so it sat in process args (visible via ps / CI logs) and could surface in git's error output. New core.git.github_https_auth context manager hands the token to git through a throwaway 0700 GIT_ASKPASS script that reads it from the child env, with a username-only URL prefix — the secret now lives only in the child environment, never in argv, URLs, or files.

- core/git.py: github_https_auth (POSIX askpass; Windows keeps credential-in-URL as a documented fallback; anonymous when no token)
- remote.py clone, pr.py push (via _git env kwarg), remediator.py org clone: routed through the helper; no token-in-URL on POSIX
- tests: helper keeps the token out of the URL and askpass file, and cleans up
- docs: note tokens are supplied via GIT_ASKPASS, never argv/URL