### PR TITLE
feat(docker): publish a GHCR container image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+# Whitelist context: start by ignoring everything, then re-include only what the wheel build
+# needs. This guarantees reports/ (which quote malware payloads), tests/ fixtures, .git, CI
+# config, and local state can never leak into the image — the same concern that shapes the
+# sdist allowlist in pyproject.toml.
+*
+!pyproject.toml
+!README.md
+!LICENSE
+!CHANGELOG.md
+!src

--- a/.github/workflows-staged/release.yml
+++ b/.github/workflows-staged/release.yml
@@ -157,3 +157,70 @@ jobs:
             --title "${GITHUB_REF_NAME}" \
             --generate-notes \
             --verify-tag
+
+  docker:
+    name: Build & publish container (GHCR)
+    # Same gate as the package: only on a tag, and only after the worm self-scan passes — the
+    # image must not ship from a release commit the scanner would reject. Independent of the
+    # PyPI job (the image builds the wheel from source), so it runs in parallel.
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [build, self-scan]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write          # push to GHCR via the built-in GITHUB_TOKEN — no extra secret
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0   # v7.0.0
+
+      - name: Derive version from tag (v0.1.0 -> 0.1.0)
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5   # v4.1.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee   # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Image tags + OCI labels
+        id: meta
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9   # v6.1.0
+        with:
+          images: ghcr.io/ndevu12/stayawakebot      # GHCR requires a lowercase path
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=sha-
+            type=raw,value=latest
+
+      - name: Build & push (with SLSA provenance + SBOM attestations)
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf   # v7.2.0
+        with:
+          context: .
+          build-args: VERSION=${{ env.VERSION }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: true       # SLSA provenance attestation pushed to GHCR
+          sbom: true             # SBOM attestation pushed to GHCR
+
+      - name: Vulnerability scan (Trivy) — report, do not block a published release on upstream CVEs
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25   # v0.36.0
+        with:
+          image-ref: ghcr.io/ndevu12/stayawakebot:${{ env.VERSION }}
+          format: sarif
+          output: trivy.sarif
+          severity: CRITICAL,HIGH
+          exit-code: '0'         # base-image CVEs shouldn't fail the release; SARIF is the record
+
+      - name: Upload Trivy SARIF
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a   # v7.0.1
+        with:
+          name: trivy-sarif
+          path: trivy.sarif
+          if-no-files-found: warn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ All notable changes to this project are documented here. The format is based on
   sentinel with `uses: Ndevu12/stayAwakeBot@v1`. It wraps the existing
   `.github/actions/worm-scan` composite (still reachable at its subpath), so no scan logic is
   duplicated and the original interface keeps working. Includes Marketplace `branding`.
+- **Container image on GHCR** (`ghcr.io/ndevu12/stayawakebot`), built and published by the
+  release pipeline's `docker` job on each `v*` tag — removes the host Python 3.14 prerequisite.
+  Multi-stage, digest-pinned base, non-root, built from the same wheel as PyPI, with SLSA
+  provenance + SBOM attestations and a Trivy scan. Adds `Dockerfile` and `.dockerignore`.
 - Versioned-release pipeline (`.github/workflows/release.yml`): tag-triggered build →
   self-scan gate → PyPI publish via Trusted Publishing (OIDC, no stored token) with PEP 740
   attestations → GitHub Release. Manual `workflow_dispatch` path publishes to TestPyPI.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,52 @@
+# syntax=docker/dockerfile:1
+#
+# StayAwakeBot container image. Goal of this channel (P3): remove the Python 3.14 install
+# barrier from the host — you need only Docker, not a 3.14 toolchain — while keeping the
+# project's supply-chain posture (digest-pinned base, non-root, hermetic build).
+#
+# Base is pinned by DIGEST, never a mutable tag (same doctrine as the SHA-pinned Actions).
+# Refresh the digest deliberately:  docker buildx imagetools inspect python:3.14-slim
+ARG PYTHON_IMAGE=python:3.14-slim@sha256:63a4c7f612a00f92042cbdcc7cdc6a306f38485af0a200b9c89de7d9b1607d15
+
+# ───────────────────────── builder: build the wheel from source ─────────────────────────
+FROM ${PYTHON_IMAGE} AS builder
+WORKDIR /build
+
+# hatch-vcs derives the version from git history, which is deliberately NOT in the build
+# context (.dockerignore). Feed the version in explicitly so the build is hermetic and needs
+# no .git. The release workflow passes the tag version; local builds get a dev placeholder.
+# NOTE: the generic PRETEND var is used, not the `_FOR_STAYAWAKEBOT` named one — hatch-vcs's
+# backend (vcs-versioning) doesn't receive the dist name, so the named variant is ignored
+# (verified). Safe here because this stage builds exactly one package.
+ARG VERSION=0.0.0.dev0+docker
+ENV SETUPTOOLS_SCM_PRETEND_VERSION=${VERSION}
+
+# Copy only what the wheel build needs (matches the Dockerfile's whitelist .dockerignore).
+COPY pyproject.toml README.md LICENSE CHANGELOG.md ./
+COPY src ./src
+
+RUN pip install --no-cache-dir build \
+ && python -m build --wheel --outdir /dist
+
+# ───────────────────────── runtime: slim, non-root, package only ────────────────────────
+FROM ${PYTHON_IMAGE} AS runtime
+
+LABEL org.opencontainers.image.source="https://github.com/Ndevu12/stayAwakeBot" \
+      org.opencontainers.image.description="StayAwakeBot — supply-chain worm hunter + uptime sentinel" \
+      org.opencontainers.image.licenses="MIT"
+
+# The scanner only ever reads code and never needs root; run as an unprivileged user.
+RUN useradd --create-home --uid 10001 sentinel
+
+COPY --from=builder /dist/*.whl /tmp/
+RUN pip install --no-cache-dir /tmp/*.whl && rm -f /tmp/*.whl
+
+USER sentinel
+WORKDIR /repo
+
+# Mount the repository to scan at /repo (read-only is fine for scanning), e.g.:
+#   docker run --rm -v "$PWD:/repo:ro" ghcr.io/ndevu12/stayawakebot \
+#     stayawake-security-scan --local-only --fail-on-findings
+# The package ships several console scripts, so there is no single ENTRYPOINT — name the
+# command you want. A bare `docker run` prints the security scanner's help.
+CMD ["stayawake-security-scan", "--help"]

--- a/README.md
+++ b/README.md
@@ -56,6 +56,18 @@ jobs:
 
 Pin `@<sha>` rather than `@v1` for tamper-evident runs. See [Security baseline](prevent/SECURITY_BASELINE.md).
 
+## Run via Docker (no local Python 3.14 needed)
+
+Prefer not to install a 3.14 toolchain? Pull the image and scan a mounted repo:
+
+```bash
+docker run --rm -v "$PWD:/repo:ro" ghcr.io/ndevu12/stayawakebot \
+  stayawake-security-scan --local-only --fail-on-findings
+```
+
+Tags: `:latest`, `:X.Y.Z`, `:X.Y`, and `:sha-<commit>`. The image runs as a non-root user, is
+built from the same wheel published to PyPI, and ships SLSA provenance + SBOM attestations.
+
 ## Documentation
 
 - [Usage](docs/USAGE.md) — install, run both bots, secrets, GitHub Actions, deploy your own

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -121,6 +121,30 @@ package is on PyPI, switch the install step in `.github/actions/worm-scan/action
 `pip install "stayawakebot==<version>"` so the gate runs a pinned, attested release instead of
 a mutable ref — and bump that version in lockstep with the moving `v1` tag.
 
+## Container image (GHCR — P3)
+
+The release workflow's `docker` job also builds and pushes a container to
+`ghcr.io/ndevu12/stayawakebot` on every `v*` tag. It needs **no extra secret** — it
+authenticates to GHCR with the built-in `GITHUB_TOKEN` (`packages: write`) — and is gated by
+the same worm self-scan as the package.
+
+One-time, after the first image is pushed:
+- Repo → **Packages** → `stayawakebot` → **Package settings**: set visibility to **Public**
+  (so `docker pull` needs no auth) and **link it to this repository**.
+
+Each release publishes `:X.Y.Z`, `:X.Y`, `:latest`, and `:sha-<commit>`, with SLSA provenance
+and an SBOM attached as attestations, plus a Trivy SARIF scan (report-only — base-image CVEs
+don't block a release; the SARIF is the audit record). The image is built from the same wheel
+as PyPI, hermetically: `hatch-vcs` can't see git inside the build, so the job passes the tag
+version via `--build-arg VERSION` → `SETUPTOOLS_SCM_PRETEND_VERSION` (the generic var; the
+`_FOR_<dist>` named variant is ignored by hatch-vcs's backend).
+
+Verify a published image:
+```bash
+docker run --rm ghcr.io/ndevu12/stayawakebot:<version> stayawake-security-scan --help
+docker buildx imagetools inspect ghcr.io/ndevu12/stayawakebot:<version>   # see provenance/SBOM
+```
+
 ## Notes & invariants
 
 - **Versioning:** `hatch-vcs` derives the version from the tag — never hand-edit a version.
@@ -138,6 +162,7 @@ Tracked here rather than silently omitted. Each is additive to the current pipel
 - [ ] **SBOM** (CycloneDX via `cyclonedx-py`) generated in the build job and attached to the
       GitHub Release.
 - [ ] **`pip-audit`** as a release gate on the dependency set.
-- [ ] **Standalone signature/sigstore step** beyond the PyPI attestations (e.g. cosign-signed
-      release assets) if we add non-PyPI channels (Docker/binaries — P3/P4).
+- [x] **Container channel (P3)** — GHCR image with SLSA provenance + SBOM attestations and a
+      Trivy scan (see *Container image* above). Remaining: standalone cosign-signed release
+      assets for any P4 binaries.
 - [ ] **Required reviewers** actually enabled on the `pypi` environment (manual, step 1).

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -16,6 +16,24 @@ The PyPI distribution is named **`stayawakebot`** because `stayawake` is already
 PyPI by an unrelated project. The import package (`stayawake`) and the `stayawake-*` console
 scripts are unchanged.
 
+### Container image (no local Python 3.14)
+
+The same code ships as a digest-pinned, non-root image on GHCR. Any console script is the
+command; mount the repository to scan at `/repo`:
+
+```bash
+docker run --rm -v "$PWD:/repo:ro" ghcr.io/ndevu12/stayawakebot \
+  stayawake-security-scan --local-only --fail-on-findings
+docker run --rm ghcr.io/ndevu12/stayawakebot stayawake-health-check --help
+```
+
+Pin a version (`ghcr.io/ndevu12/stayawakebot:0.1.0`) or a commit (`:sha-<commit>`) for
+reproducibility; `:latest` tracks the newest release. To build it yourself:
+
+```bash
+docker build --build-arg VERSION=0.1.0 -t stayawakebot:local .
+```
+
 ## Health bot — uptime monitoring
 
 Run the pipeline against `config/urls.yml`:


### PR DESCRIPTION
## What & why ( distribution strategy)

Ships the toolkit as a container so adopters need **only Docker, not a Python 3.14 toolchain**
(`requires-python >=3.14` is the single biggest install barrier today). The release pipeline
builds and pushes `ghcr.io/ndevu12/stayawakebot` on every `v*` tag.

```bash
docker run --rm -v "$PWD:/repo:ro" ghcr.io/ndevu12/stayawakebot \
  stayawake-security-scan --local-only --fail-on-findings
```

## Changes

- **`Dockerfile`** — multi-stage; base **pinned by digest** (`python:3.14-slim@sha256:63a4c7f6…`,
  resolved from the registry), non-root runtime user, built from the **same wheel as PyPI**.
- **`.dockerignore`** — whitelist (`*` then re-include `src` + metadata) so `reports/` (which
  quote malware payloads), `tests/` fixtures, and `.git` can never enter the image — same
  concern as the sdist allowlist.
- **`docker` job in the release pipeline** — gated by the worm self-scan, GHCR auth via the
  built-in `GITHUB_TOKEN` (no extra secret), tags `:X.Y.Z` / `:X.Y` / `:latest` / `:sha-…`,
  **SLSA provenance + SBOM attestations**, and a Trivy scan (report-only). All actions SHA-pinned.
- **Docs** — Docker usage in README + USAGE; GHCR runbook + backlog update in RELEASING; CHANGELOG.

## Two gaps caught during validation (and fixed)

1. **hatch-vcs has no `.git` inside Docker.** The build is made hermetic by injecting the
   version as a build arg. My first attempt used `SETUPTOOLS_SCM_PRETEND_VERSION_FOR_STAYAWAKEBOT`
   — **empirically proven to be silently ignored** (this hatch-vcs backend, `vcs-versioning`,
   doesn't receive the dist name, so the `_FOR_<dist>` branch never fires). Switched to the
   generic `SETUPTOOLS_SCM_PRETEND_VERSION`, which **is** honored. Without this catch the image
   build would have failed to detect a version.
2. **sdist-style leakage into the image** — closed via the whitelist `.dockerignore`.

## Validation

- Simulated the builder stage exactly (whitelisted files, **no `.git`**): build produced the
  correct `stayawakebot-0.1.0` wheel **and** the packaged `signatures.yml` is present.
- `release.yml` parses; `docker` job `needs: [build, self-scan]`, `packages: write`.
- Base image digest resolved from the live registry; all five Docker actions SHA-pinned.
- No worm-signature payloads introduced.
- ⚠️ The actual `docker build` couldn't run here (no daemon in this environment) — it executes
  at release time. The wheel build (the only project-specific risk) is verified above.

## Manual step remaining (maintainer)

After the first push, set the GHCR package visibility to **Public** and link it to the repo
(documented in `RELEASING.md`).

## Merge order

⚠️ **Stacked on #1003 (P0/P1)**, independent of P2 (#1006). Base is `claude/distribution-p0-p1`
so this diff is P3-only. Merge #1003 first; GitHub auto-retargets this to `main`.

