### PR TITLE
ci(release): SBOM + pip-audit gate + pre-publish Trivy gate

### DIFF
--- a/.github/workflows-staged/release.yml
+++ b/.github/workflows-staged/release.yml
@@ -55,6 +55,33 @@ jobs:
           stayawake-security-scan --help
           stayawake-health-check --help
 
+      - name: Resolve app dependencies in a clean venv (for audit + SBOM)
+        run: |
+          python -m venv /tmp/appenv
+          /tmp/appenv/bin/pip install --quiet --upgrade pip
+          /tmp/appenv/bin/pip install dist/*.whl
+          # Audit/SBOM the app's RESOLVED dependency set; drop our own dist (not on PyPI yet).
+          /tmp/appenv/bin/pip freeze | grep -ivE '^stayawakebot==' > /tmp/app-requirements.txt
+
+      - name: Audit dependencies for known vulnerabilities (gate)
+        run: |
+          pip install pip-audit
+          # Fails the release on any advisory in the resolved deps. To ship past a vuln with
+          # no fix yet, add a scoped `--ignore-vuln GHSA-xxxx` here (see docs/RELEASING.md).
+          pip-audit --strict --requirement /tmp/app-requirements.txt
+
+      - name: Generate CycloneDX SBOM
+        run: |
+          pip install cyclonedx-bom
+          cyclonedx-py environment /tmp/appenv/bin/python --of JSON -o sbom.cdx.json
+
+      - name: Upload SBOM
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a   # v7.0.1
+        with:
+          name: sbom
+          path: sbom.cdx.json
+          if-no-files-found: error
+
       - name: Upload distribution artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a   # v7.0.1
         with:
@@ -149,11 +176,16 @@ jobs:
         with:
           name: dist
           path: dist/
+      - name: Download SBOM
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c   # v8.0.1
+        with:
+          name: sbom
+          path: sbom/
       - name: Create release with auto-generated notes + artifacts
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "${GITHUB_REF_NAME}" dist/* \
+          gh release create "${GITHUB_REF_NAME}" dist/* sbom/sbom.cdx.json \
             --title "${GITHUB_REF_NAME}" \
             --generate-notes \
             --verify-tag
@@ -197,30 +229,43 @@ jobs:
             type=sha,prefix=sha-
             type=raw,value=latest
 
-      - name: Build & push (with SLSA provenance + SBOM attestations)
+      # Build the image locally first and gate it on a vulnerability scan BEFORE publishing,
+      # so a fixable critical/high never reaches GHCR (no "published-but-failed"). The push
+      # step below reuses this build from the buildx cache.
+      - name: Build image for scanning (load locally, no push yet)
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf   # v7.2.0
         with:
           context: .
           build-args: VERSION=${{ env.VERSION }}
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          provenance: true       # SLSA provenance attestation pushed to GHCR
-          sbom: true             # SBOM attestation pushed to GHCR
+          load: true
+          tags: ghcr.io/ndevu12/stayawakebot:${{ env.VERSION }}
 
-      - name: Vulnerability scan (Trivy) — report, do not block a published release on upstream CVEs
+      - name: Vulnerability gate (Trivy) — block on FIXABLE critical/high
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25   # v0.36.0
         with:
           image-ref: ghcr.io/ndevu12/stayawakebot:${{ env.VERSION }}
           format: sarif
           output: trivy.sarif
           severity: CRITICAL,HIGH
-          exit-code: '0'         # base-image CVEs shouldn't fail the release; SARIF is the record
+          ignore-unfixed: true   # don't block on CVEs with no upstream fix available yet
+          exit-code: '1'         # a fixable critical/high fails the job before anything is pushed
 
       - name: Upload Trivy SARIF
-        if: always()
+        if: always()             # keep the scan record even when the gate fails
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a   # v7.0.1
         with:
           name: trivy-sarif
           path: trivy.sarif
+          if-no-files-found: warn
+
+      - name: Build & push (with SLSA provenance + SBOM attestations)
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf   # v7.2.0
+        with:
+          context: .
+          build-args: VERSION=${{ env.VERSION }}
+          push: true             # reuses the cached build above
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: true       # SLSA provenance attestation pushed to GHCR
+          sbom: true             # SBOM attestation pushed to GHCR
           if-no-files-found: warn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project are documented here. The format is based on
 ## [Unreleased]
 
 ### Added
+- **Release-pipeline hardening:** a **CycloneDX SBOM** of the wheel's resolved dependencies,
+  generated in the build job and attached to each GitHub Release; a **`pip-audit` gate** that
+  fails the release on a known-vulnerable dependency; and the container scan is now a **Trivy
+  gate** (build → scan → push) that blocks a fixable critical/high *before* the image is pushed.
 - **GitHub Action Marketplace entry point** (`action.yml` at repo root): adopt the security
   sentinel with `uses: Ndevu12/stayAwakeBot@v1`. It wraps the existing
   `.github/actions/worm-scan` composite (still reachable at its subpath), so no scan logic is

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -159,10 +159,13 @@ docker buildx imagetools inspect ghcr.io/ndevu12/stayawakebot:<version>   # see 
 
 Tracked here rather than silently omitted. Each is additive to the current pipeline:
 
-- [ ] **SBOM** (CycloneDX via `cyclonedx-py`) generated in the build job and attached to the
-      GitHub Release.
-- [ ] **`pip-audit`** as a release gate on the dependency set.
+- [x] **SBOM** (CycloneDX via `cyclonedx-py`) — generated in the build job from the wheel's
+      resolved deps and attached to the GitHub Release as `sbom.cdx.json`.
+- [x] **`pip-audit`** — release gate on the resolved dependency set. To ship past an advisory
+      that has no fix yet, add a scoped `--ignore-vuln GHSA-xxxx` to the *Audit dependencies*
+      step (don't drop `--strict`).
 - [x] **Container channel (P3)** — GHCR image with SLSA provenance + SBOM attestations and a
-      Trivy scan (see *Container image* above). Remaining: standalone cosign-signed release
-      assets for any P4 binaries.
+      **Trivy gate**: the image is built and scanned *before* publishing, and a fixable
+      critical/high (`ignore-unfixed: true`) fails the job before anything is pushed.
+- [ ] **cosign-signed release assets** beyond the PyPI/image attestations, if/when P4 binaries land.
 - [ ] **Required reviewers** actually enabled on the `pypi` environment (manual, step 1).


### PR DESCRIPTION
## What & why (gap-closing — release hardening)

Closes the "remaining hardening backlog" the release pipeline documented as not-yet-done:

| Gap | Closure |
|---|---|
| **No SBOM** | Build job generates a **CycloneDX SBOM** from the wheel's *resolved* deps (in a clean venv, excluding our own not-yet-published dist) and attaches `sbom.cdx.json` to the GitHub Release. |
| **No dependency audit** | **`pip-audit --strict`** gate over the resolved dependency set fails the release on a known-vulnerable dep. Documented `--ignore-vuln` escape hatch for fix-less advisories. |
| **Trivy was report-only** | Now a **real gate**: the image is built and scanned **before** publishing (`build → scan → push`); a *fixable* critical/high (`ignore-unfixed: true`) fails the job, so a bad image never reaches GHCR. The push step reuses the cached build. |
| **License classifier** | Already removed earlier — verified, nothing to do. |

## Validation

- Confirmed the exact CLIs locally before wiring: `cyclonedx-py environment <python> --of JSON -o sbom.cdx.json` emits valid CycloneDX 1.6; `pip-audit --strict --requirement <file>` exits 0 clean. (First attempt used the wrong `--outfile` flag — caught and corrected.)
- `release.yml` parses; verified the **Trivy gate runs before the push step**, and the release job attaches the SBOM.
- No worm-signature payloads introduced.
- Note: the app venv install requires Python 3.14, so the SBOM *content* generation only runs in CI (3.14) — the CLI flags, the gate ordering, and the YAML are all verified here.

## Merge order

⚠️ **Stacked on #1009 (P3)** — it touches both the `build` job (SBOM/audit) and the `docker` job (Trivy), which coexist only on the P3 branch. Base is `feat/docker-image`; this is the last link in the P0/P1 → P2/P3 → hardening chain. Merge after #1009.

The evil-merge scanner fix (#1010) is the *other* gap-closer from this round and is independent (off `main`).