### PR TITLE
feat(security): GitHub App auth — nstallation tokens

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -127,7 +127,10 @@ StayAwakeBot resolves one in this order:
    never set this up: the `GITHUB_` prefix is reserved, so you *can't* even create a
    secret with that name. It's the zero-config fallback for **same-repo** work inside
    Actions, and it can't reach other repos.
-3. Your **GitHub CLI** session — `gh auth token` — short-lived and never stored by
+3. A **GitHub App** installation token — for org-wide automation (see below). Minted on
+   demand from the App's key, scoped to exactly what the App was granted, and rotated
+   every hour. Preferred over a PAT for continuous/org use.
+4. Your **GitHub CLI** session — `gh auth token` — short-lived and never stored by
    StayAwakeBot, which is what the hygiene audit recommends over a cached PAT.
 
 In short: in CI, same-repo jobs ride the automatic `GITHUB_TOKEN` for free and only
@@ -150,6 +153,35 @@ scope is in parentheses):
 | `stayawake-security-remediate --open-pr` / `--remote` | write | Contents + Pull requests: R/W (`repo`) |
 | `stayawake-security-alert` (GitHub issue) | write | Issues: R/W (`repo` / `public_repo`) |
 | `stayawake-security-audit --repo` | read | Administration: Read (`repo`) |
+
+### GitHub App (org-wide automation)
+
+For continuous, org-wide scanning/remediation, a **GitHub App** beats a human PAT: an
+admin installs it once on the chosen repos and StayAwakeBot mints a fresh **1-hour
+installation token** per run, scoped to exactly the App's granted permissions — nothing
+long-lived to leak, fully revocable, and the install itself defines which repos are in
+scope (no `targets.github` list needed). The private key stays in memory; signing is
+delegated to a vetted crypto library (never hand-rolled).
+
+It's an **opt-in extra** so the base install stays stdlib-only:
+
+```bash
+pip install "stayawake[app]"          # adds PyJWT[crypto] — only needed for App auth
+export GH_APP_ID=123456
+export GH_APP_PRIVATE_KEY="$(cat your-app.private-key.pem)"   # or GH_APP_PRIVATE_KEY_PATH=…
+# optional; auto-detected when the App has exactly one installation:
+export GH_APP_INSTALLATION_ID=98765
+stayawake-security-scan               # scans every repo the installation can see
+stayawake-security-remediate --remote # opens a dedup'd fix PR per infected install repo
+```
+
+If the App env is set without the extra installed, StayAwakeBot prints a clear
+`pip install "stayawake[app]"` hint rather than failing obscurely. An explicit
+`GH_SECURITY_TOKEN` still takes precedence (handy for a one-off human override).
+
+**Minimal App permissions** (Repository permissions): **Metadata: Read** (always) +
+**Contents: Read** to scan; add **Contents: Read & write** and **Pull requests: Read &
+write** to open remediation PRs.
 
 Other secrets:
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -154,14 +154,20 @@ scope is in parentheses):
 | `stayawake-security-alert` (GitHub issue) | write | Issues: R/W (`repo` / `public_repo`) |
 | `stayawake-security-audit --repo` | read | Administration: Read (`repo`) |
 
-### GitHub App (org-wide automation)
+### GitHub App (organization **or** personal account)
 
-For continuous, org-wide scanning/remediation, a **GitHub App** beats a human PAT: an
-admin installs it once on the chosen repos and StayAwakeBot mints a fresh **1-hour
-installation token** per run, scoped to exactly the App's granted permissions — nothing
-long-lived to leak, fully revocable, and the install itself defines which repos are in
-scope (no `targets.github` list needed). The private key stays in memory; signing is
-delegated to a vetted crypto library (never hand-rolled).
+A **GitHub App** is the hardened credential for continuous scanning/remediation, and it
+is **not org-only** — GitHub Apps install on either a personal (user) account or an
+organization, and StayAwakeBot treats both the same. You (or an org admin) install it
+once on the chosen repos and it mints a fresh **1-hour installation token** per run,
+scoped to exactly the App's granted permissions — nothing long-lived to leak, fully
+revocable, and the install itself defines which repos are in scope (no `targets.github`
+list needed). The private key stays in memory; signing is delegated to a vetted crypto
+library (never hand-rolled).
+
+For a personal account with a handful of repos, `gh auth login` or a fine-grained PAT is
+simpler. Reach for an App when you want that same rotating, narrowly-scoped, revocable
+token model on your own repos — or when you manage many.
 
 It's an **opt-in extra** so the base install stays stdlib-only:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,9 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = []   # the test suite uses the stdlib `unittest`
+# GitHub App auth (org-wide installation tokens). Opt-in so the base install stays
+# stdlib-only; only needed to run with GH_APP_ID + a private key.
+app = ["pyjwt[crypto]>=2.0"]
 
 [project.urls]
 Homepage = "https://github.com/Ndevu12/stayAwakeBot"

--- a/src/stayawake/bots/security/remediator.py
+++ b/src/stayawake/bots/security/remediator.py
@@ -149,8 +149,9 @@ def submit_org_prs(config_path: str = "config/security.yml", token: str | None =
     opts = _options(settings)
     sigs = load_signatures(settings.get("signatures_path"))
     allowlist = cfg.get("allowlist", [])
+    source = "explicit"
     if not token:
-        token, _ = auth.resolve_token()
+        token, source = auth.resolve_token()
     if not token:
         print(auth.no_credential_hint("org remediation PRs") +
               " The token needs repo + pull-request write scope.")
@@ -163,9 +164,12 @@ def submit_org_prs(config_path: str = "config/security.yml", token: str | None =
             slugs += github_api.list_repos(acct, kind, token,
                                            gconf.get("include_forks", False),
                                            gconf.get("include_archived", False))
+    # With a GitHub App and no explicit accounts, sweep everything the install can see.
+    if source == "github-app" and not slugs:
+        slugs += github_api.list_installation_repos(token, gconf.get("include_archived", False))
     slugs = sorted(set(slugs))
     if not slugs:
-        print("No GitHub targets configured (targets.github.users/orgs).")
+        print("No GitHub targets configured (targets.github.users/orgs or an App installation).")
         return 0
 
     print(f"Sweeping {len(slugs)} repo(s) for worm indicators…")

--- a/src/stayawake/bots/security/service.py
+++ b/src/stayawake/bots/security/service.py
@@ -114,6 +114,9 @@ def _resolve_remote(cfg: dict, opts: ScanOptions):
             slugs += github_api.list_repos(acct, kind, token,
                                            gconf.get("include_forks", False),
                                            gconf.get("include_archived", False))
+    # With a GitHub App and no explicit accounts, scan everything the install can see.
+    if source == "github-app" and not slugs:
+        slugs += github_api.list_installation_repos(token, gconf.get("include_archived", False))
     return sorted(set(slugs)), token, source
 
 

--- a/src/stayawake/core/adapters/github_api.py
+++ b/src/stayawake/core/adapters/github_api.py
@@ -62,6 +62,27 @@ def list_repos(account: str, kind: str, token: str | None,
     return slugs
 
 
+def list_installation_repos(token: str | None, include_archived: bool = False) -> list[str]:
+    """Repos a GitHub App installation can access ('owner/name', ...), paginated.
+    `token` must be an installation access token (see core.github_app)."""
+    slugs: list[str] = []
+    page = 1
+    while True:
+        res = request(f"/installation/repositories?per_page=100&page={page}", token=token)
+        repos = res.get("repositories") if isinstance(res, dict) else None
+        if not repos:
+            break
+        for r in repos:
+            if not include_archived and r.get("archived"):
+                continue
+            if r.get("full_name"):
+                slugs.append(r["full_name"])
+        if len(repos) < 100:
+            break
+        page += 1
+    return slugs
+
+
 def list_open_pulls(owner: str, repo: str, head_branch: str, token: str | None) -> list[dict]:
     """Open PRs whose head is `owner:head_branch` (used for de-duplication)."""
     res = request(f"/repos/{owner}/{repo}/pulls?state=open&head={owner}:{head_branch}",

--- a/src/stayawake/core/auth.py
+++ b/src/stayawake/core/auth.py
@@ -60,12 +60,30 @@ def gh_token(hostname: str = "github.com") -> str | None:
     return None
 
 
+def _app_token() -> str | None:
+    """A GitHub App installation token, or None if no App is configured. Never raises:
+    a configured-but-broken App is reported and treated as 'no token' so resolution can
+    fall through (the caller's hint then guides)."""
+    from stayawake.core import github_app  # lazy: keeps PyJWT fully optional
+    try:
+        return github_app.installation_token()
+    except github_app.GithubAppError as e:
+        print(f"GitHub App auth configured but unavailable: {e}")
+        return None
+
+
 def resolve_token(hostname: str = "github.com") -> tuple[str | None, str | None]:
-    """Return (token, source). `source` is the env var name, 'gh', or None.
-    Callers decide whether a missing token is fatal (writes) or fine (public read)."""
+    """Return (token, source). `source` is the env var name, 'github-app', 'gh', or None.
+
+    Precedence: an explicit env PAT wins (human override) → a GitHub App installation
+    token (automation default) → the gh CLI session → none. Callers decide whether a
+    missing token is fatal (writes) or fine (public read)."""
     token, source = _env_token()
     if token:
         return token, source
+    app = _app_token()
+    if app:
+        return app, "github-app"
     token = gh_token(hostname)
     if token:
         return token, "gh"

--- a/src/stayawake/core/github_app.py
+++ b/src/stayawake/core/github_app.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""GitHub App authentication — mint short-lived installation tokens.
+
+Optional feature: needs `pip install "stayawake[app]"` (PyJWT[crypto]). A GitHub App is
+the production way to scan/remediate org-wide: an admin installs it once on selected
+repos and it mints **1-hour, auto-rotating installation tokens** scoped to exactly the
+granted permissions — no human PAT to leak, fully revocable, and the install itself
+defines scope.
+
+Security: the private key stays **in memory** (never written to disk); JWT signing is
+delegated to the audited PyJWT/cryptography stack. Tokens/keys are returned to callers
+but never logged here.
+
+Configuration (env only):
+  GH_APP_ID                 numeric App ID (not secret)
+  GH_APP_PRIVATE_KEY        PEM contents of the App private key (secret), OR
+  GH_APP_PRIVATE_KEY_PATH   path to the .pem
+  GH_APP_INSTALLATION_ID    optional; if omitted and the App has exactly one
+                            installation, that one is used
+"""
+from __future__ import annotations
+
+import os
+import time
+from datetime import datetime
+from pathlib import Path
+
+from stayawake.core.adapters import github_api
+
+APP_ID_ENV = "GH_APP_ID"
+PRIVATE_KEY_ENV = "GH_APP_PRIVATE_KEY"
+PRIVATE_KEY_PATH_ENV = "GH_APP_PRIVATE_KEY_PATH"
+INSTALLATION_ID_ENV = "GH_APP_INSTALLATION_ID"
+
+_SKEW = 60          # refresh this many seconds before the API-stated expiry
+_JWT_TTL = 540      # App JWT lifetime (≤ 10 min per GitHub)
+# (app_id, installation_env) -> (installation_token, expires_epoch)
+_cache: dict[tuple[str, str], tuple[str, float]] = {}
+
+
+class GithubAppError(RuntimeError):
+    """App auth is configured but cannot be completed (missing extra, bad key, no
+    resolvable installation, API failure)."""
+
+
+def _private_key() -> str | None:
+    pem = os.environ.get(PRIVATE_KEY_ENV)
+    if pem and pem.strip():
+        return pem
+    path = os.environ.get(PRIVATE_KEY_PATH_ENV)
+    if path:
+        try:
+            return Path(path).read_text(encoding="utf-8")
+        except OSError:
+            return None
+    return None
+
+
+def is_configured() -> bool:
+    """True if a GitHub App is configured (App ID + a private-key source present)."""
+    return bool(os.environ.get(APP_ID_ENV) and _private_key())
+
+
+def _build_jwt(app_id: str, private_key: str) -> str:
+    """Sign the App JWT (RS256). Requires the optional PyJWT[crypto] extra."""
+    try:
+        import jwt  # PyJWT — only needed for App auth (optional [app] extra)
+    except ImportError as e:
+        raise GithubAppError(
+            'GitHub App auth needs PyJWT — install the extra: pip install "stayawake[app]".'
+        ) from e
+    now = int(time.time())
+    payload = {"iat": now - _SKEW, "exp": now + _JWT_TTL, "iss": app_id}
+    return jwt.encode(payload, private_key, algorithm="RS256")
+
+
+def _expiry_epoch(expires_at: str | None) -> float:
+    if expires_at:
+        try:
+            return datetime.fromisoformat(expires_at.replace("Z", "+00:00")).timestamp()
+        except ValueError:
+            pass
+    return time.time() + 3000  # ~50 min conservative default
+
+
+def _resolve_installation_id(app_jwt: str) -> str | None:
+    """Use GH_APP_INSTALLATION_ID, else the sole installation if there's exactly one."""
+    explicit = os.environ.get(INSTALLATION_ID_ENV)
+    if explicit:
+        return explicit
+    res = github_api.request("/app/installations?per_page=100", token=app_jwt)
+    if isinstance(res, list) and len(res) == 1 and res[0].get("id"):
+        return str(res[0]["id"])
+    return None
+
+
+def installation_token() -> str | None:
+    """Mint (or return a cached) installation access token.
+
+    Returns None when no App is configured (callers fall back to other credentials).
+    Raises GithubAppError when an App *is* configured but unusable."""
+    app_id = os.environ.get(APP_ID_ENV)
+    key = _private_key()
+    if not (app_id and key):
+        return None
+
+    cache_key = (app_id, os.environ.get(INSTALLATION_ID_ENV) or "")
+    cached = _cache.get(cache_key)
+    if cached and cached[1] - _SKEW > time.time():
+        return cached[0]
+
+    app_jwt = _build_jwt(app_id, key)
+    installation_id = _resolve_installation_id(app_jwt)
+    if not installation_id:
+        raise GithubAppError(
+            f"set {INSTALLATION_ID_ENV} (the App has zero or multiple installations).")
+
+    res = github_api.request(
+        f"/app/installations/{installation_id}/access_tokens", method="POST", token=app_jwt)
+    if not isinstance(res, dict) or not res.get("token"):
+        raise GithubAppError(
+            "could not mint an installation token (check the App ID, private key, and installation).")
+    token = res["token"]
+    _cache[cache_key] = (token, _expiry_epoch(res.get("expires_at")))
+    return token

--- a/tests/core/test_github_app.py
+++ b/tests/core/test_github_app.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""GitHub App auth: installation-token minting, caching, graceful degradation.
+
+These tests don't require the optional PyJWT[crypto] extra — the JWT signing seam is
+mocked, and the missing-extra path is exercised by forcing the `import jwt` to fail.
+"""
+from __future__ import annotations
+
+import builtins
+import os
+import unittest
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from unittest import mock
+
+from stayawake.core import github_app, auth
+
+_FUTURE = "2099-01-01T00:00:00Z"   # far-future expiry → cache stays valid in-test
+_APP_ENV = {"GH_APP_ID": "123", "GH_APP_PRIVATE_KEY": "-----PEM-----",
+            "GH_APP_INSTALLATION_ID": "42"}
+
+
+class TestConfig(unittest.TestCase):
+    def test_not_configured_returns_none(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertIsNone(github_app.installation_token())
+            self.assertFalse(github_app.is_configured())
+
+    def test_is_configured_with_app_env(self):
+        with mock.patch.dict(os.environ, _APP_ENV, clear=True):
+            self.assertTrue(github_app.is_configured())
+
+    def test_private_key_from_path(self):
+        with NamedTemporaryFile("w", suffix=".pem", delete=False) as f:
+            f.write("-----FROM FILE-----")
+            path = f.name
+        try:
+            with mock.patch.dict(os.environ, {"GH_APP_ID": "1", "GH_APP_PRIVATE_KEY_PATH": path},
+                                 clear=True):
+                self.assertEqual(github_app._private_key(), "-----FROM FILE-----")
+                self.assertTrue(github_app.is_configured())
+        finally:
+            os.unlink(path)
+
+
+class TestMinting(unittest.TestCase):
+    def setUp(self):
+        github_app._cache.clear()
+
+    def test_mints_token_with_explicit_installation(self):
+        with mock.patch.dict(os.environ, _APP_ENV, clear=True), \
+             mock.patch.object(github_app, "_build_jwt", return_value="JWT"), \
+             mock.patch.object(github_app.github_api, "request",
+                               return_value={"token": "ghs_inst", "expires_at": _FUTURE}) as req:
+            self.assertEqual(github_app.installation_token(), "ghs_inst")
+        # explicit installation id ⇒ only the access_tokens POST, no discovery call
+        req.assert_called_once()
+        self.assertIn("/app/installations/42/access_tokens", req.call_args.args[0])
+
+    def test_caches_token(self):
+        with mock.patch.dict(os.environ, _APP_ENV, clear=True), \
+             mock.patch.object(github_app, "_build_jwt", return_value="JWT"), \
+             mock.patch.object(github_app.github_api, "request",
+                               return_value={"token": "ghs_inst", "expires_at": _FUTURE}) as req:
+            github_app.installation_token()
+            github_app.installation_token()        # second call should be cached
+        req.assert_called_once()
+
+    def test_resolves_single_installation(self):
+        env = {k: v for k, v in _APP_ENV.items() if k != "GH_APP_INSTALLATION_ID"}
+        calls = {"n": 0}
+
+        def fake_request(path, method="GET", token=None, data=None):
+            calls["n"] += 1
+            if path.startswith("/app/installations?"):
+                return [{"id": 7}]                  # exactly one installation
+            return {"token": "ghs_one", "expires_at": _FUTURE}
+
+        with mock.patch.dict(os.environ, env, clear=True), \
+             mock.patch.object(github_app, "_build_jwt", return_value="JWT"), \
+             mock.patch.object(github_app.github_api, "request", side_effect=fake_request):
+            self.assertEqual(github_app.installation_token(), "ghs_one")
+
+    def test_no_resolvable_installation_raises(self):
+        env = {k: v for k, v in _APP_ENV.items() if k != "GH_APP_INSTALLATION_ID"}
+        with mock.patch.dict(os.environ, env, clear=True), \
+             mock.patch.object(github_app, "_build_jwt", return_value="JWT"), \
+             mock.patch.object(github_app.github_api, "request", return_value=[]):  # 0 installs
+            with self.assertRaises(github_app.GithubAppError):
+                github_app.installation_token()
+
+    def test_mint_failure_raises(self):
+        with mock.patch.dict(os.environ, _APP_ENV, clear=True), \
+             mock.patch.object(github_app, "_build_jwt", return_value="JWT"), \
+             mock.patch.object(github_app.github_api, "request", return_value=None):  # API failed
+            with self.assertRaises(github_app.GithubAppError):
+                github_app.installation_token()
+
+
+class TestMissingExtra(unittest.TestCase):
+    def test_build_jwt_without_pyjwt_points_at_extra(self):
+        real_import = builtins.__import__
+
+        def no_jwt(name, *a, **k):
+            if name == "jwt":
+                raise ImportError("no module named jwt")
+            return real_import(name, *a, **k)
+
+        with mock.patch.object(builtins, "__import__", side_effect=no_jwt):
+            with self.assertRaises(github_app.GithubAppError) as ctx:
+                github_app._build_jwt("123", "KEY")
+        self.assertIn("stayawake[app]", str(ctx.exception))
+
+
+class TestResolveTokenIntegration(unittest.TestCase):
+    def test_app_token_used_when_no_env_pat(self):
+        with mock.patch.dict(os.environ, {}, clear=True), \
+             mock.patch.object(github_app, "installation_token", return_value="ghs_app"), \
+             mock.patch.object(auth, "gh_token", return_value=None):
+            self.assertEqual(auth.resolve_token(), ("ghs_app", "github-app"))
+
+    def test_env_pat_beats_app(self):
+        with mock.patch.dict(os.environ, {"GH_SECURITY_TOKEN": "pat"}, clear=True), \
+             mock.patch.object(github_app, "installation_token") as inst:
+            self.assertEqual(auth.resolve_token(), ("pat", "GH_SECURITY_TOKEN"))
+            inst.assert_not_called()   # env PAT wins; App never consulted
+
+    def test_app_error_falls_through_to_none(self):
+        with mock.patch.dict(os.environ, {}, clear=True), \
+             mock.patch.object(github_app, "installation_token",
+                               side_effect=github_app.GithubAppError("boom")), \
+             mock.patch.object(auth, "gh_token", return_value=None):
+            self.assertEqual(auth.resolve_token(), (None, None))
+
+
+class TestInstallationRepos(unittest.TestCase):
+    def test_list_installation_repos_paginates_and_skips_archived(self):
+        from stayawake.core.adapters import github_api
+        page1 = {"repositories": [{"full_name": f"o/r{i}"} for i in range(100)]}
+        page2 = {"repositories": [{"full_name": "o/last"}, {"full_name": "o/arch", "archived": True}]}
+        pages = [page1, page2]
+        with mock.patch.object(github_api, "request", side_effect=lambda *a, **k: pages.pop(0)):
+            repos = github_api.list_installation_repos("ghs_inst")
+        self.assertIn("o/r0", repos)
+        self.assertIn("o/last", repos)
+        self.assertNotIn("o/arch", repos)          # archived skipped by default
+        self.assertEqual(len(repos), 101)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds the production credential for org-wide scanning/remediation: a GitHub App, installed once by an admin, mints 1-hour auto-rotating installation tokens scoped to exactly the granted permissions — no human PAT, fully revocable, and the install defines which repos are in scope.

- core/github_app.py: build an RS256 App JWT (PyJWT[crypto]) → POST access_tokens → cached installation token; resolves a single installation automatically; private key stays in memory (no disk); raises a clear hint if the extra/key/installation is missing
- auth.resolve_token: precedence env PAT → App installation token → gh → none; a configured-but-broken App reports and falls through rather than crashing
- github_api.list_installation_repos: enumerate the install's repos (paginated)
- service/remediator: when an App is configured and no accounts are listed, scan/sweep everything the installation can see
- pyproject: opt-in extra `stayawake[app]` (PyJWT[crypto]) — base install stays stdlib-only
- tests: minting/caching/installation-resolution/missing-extra/resolve-token precedence, all passing without PyJWT installed (graceful path proven)
- docs: Authentication App subsection (setup + minimal App permissions)