### PR TITLE
feat(security): notify-issue fallback when a fix branch can't be pushed

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -63,9 +63,11 @@ stayawake-security-remediate --remote           # operate on remote GitHub targe
 ```
 
 **Read-only fallback:** when `--open-pr` / `--remote` can't push a fix branch (you only
-have read access to the target), StayAwakeBot doesn't discard the fix — it writes it as a
-`git am`-able patch under `sab-patches/` and tells you how to apply it. So remediation
-always produces something actionable, even without write access.
+have read access to the target), StayAwakeBot doesn't discard the fix — it degrades
+gracefully: it writes the fix as a `git am`-able patch under `sab-patches/`, **and** (if
+the token has `issues: write`) opens a **de-duplicated issue** on the target repo with
+the findings so the owner is notified. So remediation always produces something
+actionable — a patch, a heads-up, or both — even without write access.
 
 Drop `--local-only` to also scan the GitHub users/orgs listed in `config/security.yml`.
 Use `--fail-on-findings` to make `scan` exit non-zero (the CI gate uses this).
@@ -151,6 +153,7 @@ scope is in parentheses):
 | `stayawake-security-scan <path>` / public remotes | no | — |
 | `stayawake-security-scan` private remotes | read | Contents + Metadata: Read (`repo`) |
 | `stayawake-security-remediate --open-pr` / `--remote` | write | Contents + Pull requests: R/W (`repo`) |
+| ↳ read-only fallback (notify issue when a PR can't be pushed) | issues | Issues: R/W (`repo` / `public_repo`) |
 | `stayawake-security-alert` (GitHub issue) | write | Issues: R/W (`repo` / `public_repo`) |
 | `stayawake-security-audit --repo` | read | Administration: Read (`repo`) |
 

--- a/src/stayawake/bots/security/pr.py
+++ b/src/stayawake/bots/security/pr.py
@@ -24,6 +24,7 @@ from stayawake.bots.security import remediation
 
 FIX_BRANCH = "security/auto-clean"
 PATCHES_DIR = Path("sab-patches")   # where the read-only fallback writes .patch files
+ISSUE_LABEL = "stayawake-security"  # de-dup marker for the issue fallback
 _BOT = ("-c", "user.name=StayAwakeBot Security", "-c", "user.email=security-bot@stayawake.local")
 
 
@@ -53,6 +54,37 @@ def _save_patch(wt: Path, slug: str, out_dir: Path) -> Path | None:
     except OSError:
         return None
     return dest
+
+
+def _issue_body(slug: str, findings) -> str:
+    lines = [f"StayAwakeBot detected self-propagating worm indicators in `{slug}` and could "
+             "not open a fix PR automatically (no write access to this repository).",
+             "", "## Indicators", ""]
+    for f in findings[:50]:
+        loc = f.path + (f":{f.line}" if getattr(f, "line", None) else "")
+        lines.append(f"- **[{f.severity.label()}]** `{f.signature_id}` — `{loc}`")
+    lines += ["", "A remediation has been generated. To apply it, grant the scanner repo + "
+              "pull-request write access for an automated PR, or run "
+              "`stayawake-security-remediate` against a local clone to produce a patch.", "",
+              "_Opened by StayAwakeBot Security. De-duplicated — re-runs won't open another._"]
+    return "\n".join(lines)
+
+
+def _open_issue_fallback(owner: str, name: str, findings, token: str) -> str | None:
+    """Notify the repo via a de-duplicated issue when a fix can't be PR'd. Needs only
+    `issues: write`; returns a short outcome, or None if it couldn't open one."""
+    try:
+        existing = github_api.list_open_issues(owner, name, token, labels=ISSUE_LABEL)
+        if existing:
+            return f"an open issue already tracks this (#{existing[0].get('number')})"
+        issue = github_api.create_issue(
+            owner, name, f"StayAwakeBot: worm indicators detected in {owner}/{name}",
+            _issue_body(f"{owner}/{name}", findings), token, labels=[ISSUE_LABEL])
+        if issue and issue.get("number"):
+            return f"opened issue #{issue['number']} ({issue.get('html_url', '')})"
+    except Exception:  # noqa: BLE001 — notification is best-effort; never mask the patch result
+        pass
+    return None
 
 
 def slug_from_url(url: str) -> str | None:
@@ -140,14 +172,20 @@ def submit_fix_pr(repo: Path, opts, signatures, allowlist, token: str,
             pushed = _git(wt, "push", "--force", f"{prefix}{slug}.git",
                           f"{FIX_BRANCH}:{FIX_BRANCH}", env=env).returncode == 0
         if not pushed:
-            # No write access: don't lose the fix when the worktree is removed — save it
-            # as a patch the repo owner can apply themselves.
+            # No write access — degrade gracefully instead of losing the work:
+            #   1) save the fix as a patch the owner can apply (needs no permissions),
+            #   2) notify the repo via a de-duplicated issue (needs only issues:write).
             patch = _save_patch(wt, slug, Path(patches_dir) if patches_dir else PATCHES_DIR)
+            issue = _open_issue_fallback(owner, name, findings, token)
+            bits = []
             if patch:
-                return (f"{slug}: push rejected (no write access?) — saved the fix as a patch at "
-                        f"{patch}. Apply on '{base}' with `git am {patch.name}`, or re-run with a "
-                        f"token that has repo + PR write scope.")
-            return f"{slug}: branch push failed (check token write scope)"
+                bits.append(f"saved the fix as a patch at {patch} "
+                            f"(apply on '{base}' with `git am {patch.name}`)")
+            if issue:
+                bits.append(issue)
+            if not bits:
+                return f"{slug}: branch push failed (check token write scope)"
+            return f"{slug}: push rejected (no write access?) — " + "; ".join(bits) + "."
 
         if existing:
             pr = existing[0]

--- a/src/stayawake/core/adapters/github_api.py
+++ b/src/stayawake/core/adapters/github_api.py
@@ -97,6 +97,28 @@ def create_pull(owner: str, repo: str, title: str, head: str, base: str,
                    data={"title": title, "head": head, "base": base, "body": body})
 
 
+def list_open_issues(owner: str, repo: str, token: str | None,
+                     labels: str | None = None) -> list[dict]:
+    """Open issues (PRs filtered out), optionally restricted to a label. Used to
+    de-duplicate the remediation issue fallback."""
+    path = f"/repos/{owner}/{repo}/issues?state=open&per_page=100"
+    if labels:
+        path += f"&labels={labels}"
+    res = request(path, token=token)
+    # The issues endpoint also returns PRs; real issues lack a 'pull_request' key.
+    return [i for i in res if isinstance(i, dict) and "pull_request" not in i] \
+        if isinstance(res, list) else []
+
+
+def create_issue(owner: str, repo: str, title: str, body: str, token: str | None,
+                 labels: list[str] | None = None) -> dict | None:
+    """Open an issue. Returns the created issue dict (with 'number','html_url') or None."""
+    data: dict = {"title": title, "body": body}
+    if labels:
+        data["labels"] = labels
+    return request(f"/repos/{owner}/{repo}/issues", method="POST", token=token, data=data)
+
+
 def get_branch_protection(owner: str, repo: str, branch: str,
                           token: str | None) -> dict | None:
     """Branch-protection settings for a branch, or None if unprotected/inaccessible.

--- a/tests/bots/security/test_pr.py
+++ b/tests/bots/security/test_pr.py
@@ -79,11 +79,11 @@ class TestNoDuplicatePr(unittest.TestCase):
         self.assertIn("ABORTED", outcome)
 
 
-class TestPatchFallback(unittest.TestCase):
-    def test_push_failure_saves_patch_instead_of_losing_fix(self):
-        # No write access: the branch push fails, so the fix must be written as a patch
-        # (the no-write floor of the remediation ladder), not silently discarded.
-        out = Path(tempfile.mkdtemp())
+class TestReadOnlyFallback(unittest.TestCase):
+    """When the fix branch can't be pushed (no write access), the remediation ladder
+    must still produce something: a patch artifact AND a de-duplicated notify issue."""
+
+    def _run(self, existing_issues, out):
         finding = Finding("x", "code-loader", Severity.CRITICAL, "postcss.config.mjs",
                           "loader", remediation="strip-appended-payload")
         scans = [ScanResult("owner/repo", "local", [finding]),   # worktree scan: infected
@@ -110,15 +110,30 @@ class TestPatchFallback(unittest.TestCase):
              mock.patch.object(pr.remediation, "apply",
                                return_value=[Change("strip-payload", "postcss.config.mjs")]), \
              mock.patch.object(pr.github_api, "list_open_pulls", return_value=[]), \
-             mock.patch.object(pr.github_api, "create_pull") as create:
+             mock.patch.object(pr.github_api, "create_pull") as create_pull, \
+             mock.patch.object(pr.github_api, "list_open_issues", return_value=existing_issues), \
+             mock.patch.object(pr.github_api, "create_issue",
+                               return_value={"number": 5, "html_url": "iu"}) as create_issue:
             outcome = pr.submit_fix_pr(Path("/repo"), object(), {}, [], token="t",
                                        patches_dir=out)
+        return outcome, create_pull, create_issue
 
-        create.assert_not_called()                       # no PR opened
+    def test_saves_patch_and_opens_issue(self):
+        out = Path(tempfile.mkdtemp())
+        outcome, create_pull, create_issue = self._run([], out)
+        create_pull.assert_not_called()                  # no PR opened
+        create_issue.assert_called_once()                # notify issue opened
         self.assertIn("patch", outcome.lower())
+        self.assertIn("issue #5", outcome)
         patch_file = out / "owner-repo.patch"
         self.assertTrue(patch_file.is_file(), "fix must be saved as a patch on push failure")
         self.assertIn("patch-body", patch_file.read_text(encoding="utf-8"))
+
+    def test_issue_is_deduplicated(self):
+        out = Path(tempfile.mkdtemp())
+        outcome, _, create_issue = self._run([{"number": 9}], out)
+        create_issue.assert_not_called()                 # an open issue exists ⇒ no duplicate
+        self.assertIn("#9", outcome)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Next rung of the remediation ladder. When submit_fix_pr can't push (read-only access), in addition to saving the patch it now opens a de-duplicated issue on the target repo with the findings — so the owner is notified through a channel that needs only issues:write (lower privilege than PR write). Patch (artifact) and issue (notification) degrade independently; if neither is possible the prior "push failed" message stands.

- github_api: list_open_issues (PRs filtered out) + create_issue, with a label for dedup
- pr.py: _issue_body + _open_issue_fallback (best-effort, never masks the patch result); push-failure path composes patch + issue into one outcome
- tests: read-only fallback opens a patch AND a dedup'd issue; existing issue ⇒ no dup
- docs: read-only fallback + minimal-scopes table note the issues:write fallback