### PR TITLE
ci(release): exclude self from pip-audit gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,9 @@ jobs:
           /tmp/appenv/bin/pip install --quiet --upgrade pip
           /tmp/appenv/bin/pip install dist/*.whl
           # Audit/SBOM the app's RESOLVED dependency set; drop our own dist (not on PyPI yet).
-          /tmp/appenv/bin/pip freeze | grep -ivE '^stayawakebot==' > /tmp/app-requirements.txt
+          # `--exclude` matches by name, so it drops the project whether `pip freeze` emits it
+          # as `stayawakebot==X` or, for a wheel installed by path, `stayawakebot @ file://…`.
+          /tmp/appenv/bin/pip freeze --exclude stayawakebot > /tmp/app-requirements.txt
 
       - name: Audit dependencies for known vulnerabilities (gate)
         run: |


### PR DESCRIPTION
## Problem
The first real run of the `release.yml` pipeline (tag `v0.1.1`) failed at the **Audit dependencies** gate:

```
ERROR:pip_audit._cli:stayawakebot: Dependency not found on PyPI and could not be audited: stayawakebot (0.1.1)
```

The build job resolves the app's dependencies in a clean venv and audits them, excluding the project's own dist (not on PyPI yet) via:

```
pip freeze | grep -ivE '^stayawakebot==' > /tmp/app-requirements.txt
```

But the wheel is installed **by path** (`pip install dist/*.whl`), so `pip freeze` emits a direct reference — `stayawakebot @ file:///…whl` — not `stayawakebot==0.1.1`. The `^stayawakebot==` filter misses it, the project leaks into the audit input, and `pip-audit --strict` errors because 0.1.1 isn't on PyPI. This blocks `publish-pypi`, `docker`, and `github-release`.

## Fix
Use `pip freeze --exclude stayawakebot`, which drops the project by **name** regardless of whether freeze emits `==` or a `@ file://` direct reference.

## Impact
- Only the dependency-resolution line in the release build job changes; the actual audit (`pip-audit --strict` over real deps) is unchanged.
- The `v0.1.1` release published nothing (gate failed before any publish step), so no artifacts exist to reconcile.