### PR TITLE
build(docker): run pip as non-root in both build stages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,17 @@ ARG PYTHON_IMAGE=python:3.14-slim@sha256:63a4c7f612a00f92042cbdcc7cdc6a306f38485
 
 # ───────────────────────── builder: build the wheel from source ─────────────────────────
 FROM ${PYTHON_IMAGE} AS builder
+
+# Build as an unprivileged user so pip never runs as root (no root-owned caches, none of the
+# "running pip as the root user" hazard) even though this stage is discarded. The only root
+# steps are useradd + mkdir/chown of the work dirs — never pip.
+RUN useradd --create-home --uid 10001 builder \
+ && mkdir /build /dist \
+ && chown builder:builder /build /dist
+USER builder
 WORKDIR /build
+# `pip install --user` keeps build's deps in the user site; put its console scripts on PATH.
+ENV PATH=/home/builder/.local/bin:$PATH
 
 # hatch-vcs derives the version from git history, which is deliberately NOT in the build
 # context (.dockerignore). Feed the version in explicitly so the build is hermetic and needs
@@ -22,10 +32,10 @@ ARG VERSION=0.0.0.dev0+docker
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=${VERSION}
 
 # Copy only what the wheel build needs (matches the Dockerfile's whitelist .dockerignore).
-COPY pyproject.toml README.md LICENSE CHANGELOG.md ./
-COPY src ./src
+COPY --chown=builder:builder pyproject.toml README.md LICENSE CHANGELOG.md ./
+COPY --chown=builder:builder src ./src
 
-RUN pip install --no-cache-dir build \
+RUN pip install --no-cache-dir --user build \
  && python -m build --wheel --outdir /dist
 
 # ───────────────────────── runtime: slim, non-root, package only ────────────────────────
@@ -35,13 +45,19 @@ LABEL org.opencontainers.image.source="https://github.com/Ndevu12/stayAwakeBot" 
       org.opencontainers.image.description="StayAwakeBot — supply-chain worm hunter + uptime sentinel" \
       org.opencontainers.image.licenses="MIT"
 
-# The scanner only ever reads code and never needs root; run as an unprivileged user.
-RUN useradd --create-home --uid 10001 sentinel
+# The scanner only ever reads code and never needs root; run as an unprivileged user, and
+# install the wheel into a user-owned virtualenv so pip runs as `sentinel`, never root. The
+# root steps here are useradd / venv creation / chown only — pip itself runs unprivileged.
+RUN useradd --create-home --uid 10001 sentinel \
+ && python -m venv /opt/venv \
+ && chown -R sentinel:sentinel /opt/venv
+ENV PATH=/opt/venv/bin:$PATH
 
-COPY --from=builder /dist/*.whl /tmp/
-RUN pip install --no-cache-dir /tmp/*.whl && rm -f /tmp/*.whl
+COPY --from=builder --chown=sentinel:sentinel /dist/*.whl /tmp/
 
 USER sentinel
+RUN pip install --no-cache-dir /tmp/*.whl && rm -f /tmp/*.whl
+
 WORKDIR /repo
 
 # Mount the repository to scan at /repo (read-only is fine for scanning), e.g.:


### PR DESCRIPTION
## Why
The container build ran `pip install` **as root** in both the builder and runtime stages, emitting:

```
WARNING: Running pip as the 'root' user can result in broken permissions ...
```

Running pip as root in an image is an avoidable hardening gap (root-owned site-packages/caches, larger blast radius if a build/install step is compromised).

## What
`pip` now runs only as an unprivileged user in **both** stages:

- **builder:** build the wheel as a `builder` user with `pip install --user build` (only `useradd` + `mkdir/chown` of the work dirs run as root — never pip).
- **runtime:** create the `sentinel` user and a **user-owned virtualenv** at `/opt/venv`, switch `USER sentinel`, then `pip install` the wheel into the venv as that user. Console scripts resolve via `/opt/venv/bin` on `PATH`.

No behavior change to the shipped CLI; the base image, digest pin, version-injection, and non-root runtime posture are unchanged.

## Verified locally
- `docker build` succeeds; the built image runs as `uid=10001(sentinel)`.
- `stayawake-security-scan` resolves to `/opt/venv/bin/stayawake-security-scan` and `--help` works.
- **Zero** `Running pip as the 'root' user` warnings across the full build (was ≥2).