### PR TITLE
ci(release): make GitHub Release step idempotent (create-or-upload)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,10 +193,18 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "${GITHUB_REF_NAME}" dist/* sbom/sbom.cdx.json \
-            --title "${GITHUB_REF_NAME}" \
-            --generate-notes \
-            --verify-tag
+          # Idempotent: if the release was pre-created (e.g. by hand) the create call would
+          # fail with "release already exists", so upload the artifacts to the existing
+          # release instead. A fresh run still creates it with generated notes.
+          if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
+            echo "Release ${GITHUB_REF_NAME} already exists — uploading artifacts to it."
+            gh release upload "${GITHUB_REF_NAME}" dist/* sbom/sbom.cdx.json --clobber
+          else
+            gh release create "${GITHUB_REF_NAME}" dist/* sbom/sbom.cdx.json \
+              --title "${GITHUB_REF_NAME}" \
+              --generate-notes \
+              --verify-tag
+          fi
 
   docker:
     name: Build & publish container (GHCR)


### PR DESCRIPTION
## Why
On the v0.1.2 release, the **Create GitHub Release** job failed:

```
a release with the same tag name already exists: v0.1.2
##[error]Process completed with exit code 1.
```

`gh release create` hard-fails if a release for the tag already exists (e.g. one created by hand before the tag-triggered run). That turned an otherwise-successful release (PyPI ✅, GHCR ✅) red, and — because the create failed — the wheel/sdist + SBOM never got attached to the release.

## Fix
Make the step **create-or-upload**: if the release already exists, upload the artifacts to it (`--clobber`); otherwise create it with generated notes as before.

```bash
if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
  gh release upload "${GITHUB_REF_NAME}" dist/* sbom/sbom.cdx.json --clobber
else
  gh release create "${GITHUB_REF_NAME}" dist/* sbom/sbom.cdx.json \
    --title "${GITHUB_REF_NAME}" --generate-notes --verify-tag
fi
```

A normal tag-triggered release is unchanged (still creates with auto-notes + `--verify-tag`); a pre-existing release now gets its artifacts attached instead of failing the run. YAML + shell validated locally.