### PR TITLE
feat(health): one self-updating issue per project (stop the [DOWN] flood)

### DIFF
--- a/.github/workflows/stayawake-sentinel.yml
+++ b/.github/workflows/stayawake-sentinel.yml
@@ -10,6 +10,7 @@ on:
         required: false
         default: 'config/urls.yml'
   push:
+    branches: [main]      # only on main — never commit reports onto feature/PR branches
     paths:
       - 'config/urls.yml'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,14 @@ All notable changes to this project are documented here. The format is based on
 - This changelog.
 
 ### Changed
+- **Health alerting now keeps one self-updating issue per project** instead of opening a new
+  `[DOWN]` issue every run. The GitHub issue is the source of truth (found by a stable hidden
+  marker, not a history flag), so a lost/rebuilt history can't produce duplicates: while a
+  project is down the body is refreshed **silently**, a comment is posted **only on state
+  transitions** (first DOWN, then recovery), and the issue is **closed on recovery** (with a
+  configurable `consecutive_healthy_before_recovery` debounce). The body now names the **failing
+  dimension** (status / latency / keyword / TLS) — previously a keyword/latency/TLS failure showed
+  a bare "DOWN" with no reason — and includes a collapsed incident log of recent transitions.
 - **Lowered the minimum Python to 3.13** (`requires-python >=3.13`, was `>=3.14`) — the code
   uses no 3.14-only features, so this widens who can `pip install stayawakebot`. Verified by
   running the full test suite on a real Python 3.13 interpreter (96/96 pass).

--- a/config/urls.yml
+++ b/config/urls.yml
@@ -5,6 +5,9 @@ settings:
   alert_on_failure: true
   alert_on_recovery: true
   consecutive_failures_before_alert: 2
+  # Recovery debounce: require this many consecutive healthy checks before declaring
+  # recovery (closes the issue). Defaults to consecutive_failures_before_alert.
+  consecutive_healthy_before_recovery: 2
   # Optional: where reports are written (default: reports). Override per run with
   # --reports-dir; set a scratch path here to keep committed reports untouched.
   # reports_dir: reports

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -10,6 +10,7 @@ settings:            # global defaults
   alert_on_failure: true
   alert_on_recovery: true
   consecutive_failures_before_alert: 1
+  consecutive_healthy_before_recovery: 1   # recovery debounce (defaults to the failure threshold)
 urls:
   - name: Example
     url: https://example.com
@@ -28,7 +29,12 @@ urls:
 - `alert_on_failure` (bool) — enable failure alerts
 - `alert_on_recovery` (bool) — enable recovery alerts
 - `consecutive_failures_before_alert` (int) — require this many consecutive failures before alerting
+- `consecutive_healthy_before_recovery` (int, optional) — require this many consecutive healthy checks before declaring recovery (debounces flapping endpoints; defaults to `consecutive_failures_before_alert`)
 - `reports_dir` (string, optional) — where reports are written (default `reports`); also settable per run with `--reports-dir`
+
+### GitHub issue alerting (health bot)
+
+The sentinel keeps **one self-updating issue per project** (label `stayawakebot-sentinel`), found by a stable hidden marker in the body rather than the title. While a project is down the issue body is **refreshed silently** (edits don't notify); a comment is posted **only on state transitions** — the first DOWN (issue opened) and recovery (one comment, then the issue is **closed**). The body names the *failing dimension* (status / latency / keyword / TLS) and carries a collapsed incident log of recent transitions, so the tracker shows only active incidents instead of one issue per run.
 
 **`urls`** (list of URLs to check)
 - `name` (required) — friendly name

--- a/src/stayawake/bots/health/alerter.py
+++ b/src/stayawake/bots/health/alerter.py
@@ -3,22 +3,38 @@
 
 Single responsibility: alerting policy + dispatch. Network I/O is delegated to
 the slack and github_api adapters.
+
+Issue model: ONE self-updating issue per monitored project. The GitHub issue is
+the source of truth (found by a stable hidden marker), not a flag in history — so
+a lost/rebuilt history can never produce duplicate issues. The body is refreshed
+silently (edits don't notify); a comment is posted only on a state transition
+(first DOWN, then recovery), and the issue is closed on recovery.
 """
 from __future__ import annotations
 
 import os
-import urllib.parse
+import re
 from pathlib import Path
 
 from stayawake.core.adapters.slack import send_slack
 from stayawake.core.adapters import github_api
 from stayawake.core.config import load_yaml
-from stayawake.core.io import read_json, write_json
+from stayawake.core.io import read_json
 from stayawake.core.timeutil import utc_stamp
 
+LABEL = "stayawakebot-sentinel"
 
-def _title(prefix: str, name: str, url: str) -> str:
-    return f"[{prefix}] {name} — {url}"
+
+def _slug(name: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", (name or "").lower()).strip("-") or "project"
+
+
+def _marker(slug: str) -> str:
+    return f"<!-- stayawakebot-sentinel:{slug} -->"
+
+
+def _title(name: str) -> str:
+    return f"\U0001F534 {name} — DOWN"   # 🔴
 
 
 def _consecutive_failures(history: list, name: str) -> int:
@@ -29,6 +45,118 @@ def _consecutive_failures(history: list, name: str) -> int:
             break
         count += 1
     return count
+
+
+def _consecutive_healthy(history: list, name: str) -> int:
+    count = 0
+    for run in reversed(history):
+        found = next((u for u in run.get("urls", []) if u.get("name") == name), None)
+        if found is None or not found.get("healthy"):
+            break
+        count += 1
+    return count
+
+
+def _transitions(history: list, name: str) -> list[dict]:
+    """State changes (healthy<->unhealthy) for one project, oldest first."""
+    out: list[dict] = []
+    prev: bool | None = None
+    for run in history:
+        u = next((x for x in run.get("urls", []) if x.get("name") == name), None)
+        if u is None:
+            continue
+        h = bool(u.get("healthy"))
+        if prev is None or h != prev:
+            out.append({"at": u.get("checked_at") or run.get("generated_at"),
+                        "healthy": h, "reason": u.get("reason") or u.get("error")})
+            prev = h
+    return out
+
+
+def _fmt_ts(iso: str | None) -> str:
+    if not iso:
+        return "unknown"
+    try:
+        from datetime import datetime
+        return datetime.fromisoformat(iso).strftime("%Y-%m-%d %H:%M UTC")
+    except Exception:
+        return str(iso)
+
+
+def _humanize(start_iso: str | None, end_iso: str | None) -> str:
+    try:
+        from datetime import datetime
+        start = datetime.fromisoformat(start_iso)
+        end = datetime.fromisoformat(end_iso) if end_iso else None
+        if end is None:
+            from stayawake.core.timeutil import now_iso
+            end = datetime.fromisoformat(now_iso())
+        secs = max(0, int((end - start).total_seconds()))
+        h, rem = divmod(secs, 3600)
+        m, _ = divmod(rem, 60)
+        return f"{h}h {m:02d}m" if h else f"{m}m"
+    except Exception:
+        return "—"
+
+
+def _outage_start(transitions: list[dict]) -> str | None:
+    """Timestamp of the most recent DOWN transition (start of the current outage)."""
+    for t in reversed(transitions):
+        if not t["healthy"]:
+            return t["at"]
+    return None
+
+
+def _incident_log(transitions: list[dict], limit: int = 10) -> str:
+    rows = []
+    # newest first; pair each recovery with the preceding outage to show downtime
+    for i in range(len(transitions) - 1, -1, -1):
+        t = transitions[i]
+        when = _fmt_ts(t["at"])
+        if t["healthy"]:
+            down_at = transitions[i - 1]["at"] if i > 0 else None
+            dur = f" (down {_humanize(down_at, t['at'])})" if down_at else ""
+            rows.append(f"| {when} | \U0001F7E2 Recovered{dur} |")
+        else:
+            reason = t.get("reason") or "unhealthy"
+            rows.append(f"| {when} | \U0001F534 DOWN — {reason} |")
+    extra = len(rows) - limit
+    rows = rows[:limit]
+    table = ("| When (UTC) | Event |\n|---|---|\n" + "\n".join(rows)) if rows else "_no recorded transitions_"
+    if extra > 0:
+        table += f"\n\n*+{extra} earlier transition(s) — see `reports/history.json`*"
+    return table
+
+
+def _render_body(name: str, url: str, u: dict, history: list, slug: str) -> str:
+    reason = u.get("reason") or u.get("error") or "unhealthy"
+    transitions = _transitions(history, name)
+    since = _outage_start(transitions)
+    code = u.get("status_code") if u.get("status_code") is not None else "—"
+    rms = f"{u.get('response_ms')} ms" if u.get("response_ms") is not None else "—"
+    dns = f" · DNS {u.get('dns_ms')} ms" if u.get("dns_ms") is not None else ""
+    consec = _consecutive_failures(history, name)
+    return "\n".join([
+        _marker(slug),
+        f"### \U0001F534 DOWN — {reason}",
+        f"**{url}**",
+        "",
+        "| | |",
+        "|---|---|",
+        f"| Status | \U0001F534 Unhealthy since **{_fmt_ts(since)}** ({_humanize(since, None)}) |",
+        f"| Failing check | {reason} |",
+        f"| HTTP | {code} · {rms}{dns} |",
+        f"| Consecutive failures | {consec} |",
+        f"| Last checked | {_fmt_ts(u.get('checked_at'))} |",
+        "",
+        "<details><summary>Incident log (last 10 transitions)</summary>",
+        "",
+        _incident_log(transitions),
+        "</details>",
+        "",
+        f"<sub>Auto-updated by StayAwakeBot Sentinel · last update {utc_stamp()} · "
+        f"body edits are silent; comments only on state changes.</sub>",
+    ])
 
 
 def run(latest_path: str | Path = "reports/latest.json",
@@ -42,62 +170,82 @@ def run(latest_path: str | Path = "reports/latest.json",
     token = os.environ.get("GITHUB_TOKEN")
     repo = os.environ.get("GITHUB_REPOSITORY")
     slack_webhook = os.environ.get("SLACK_WEBHOOK_URL")
+    owner = repo_name = None
+    if repo and "/" in repo:
+        owner, repo_name = repo.split("/", 1)
 
     try:
         settings = load_yaml("config/urls.yml").get("settings", {})
     except Exception:
         settings = {}
-    threshold = int(settings.get("consecutive_failures_before_alert", 1))
+    fail_threshold = int(settings.get("consecutive_failures_before_alert", 1))
+    # Recovery debounce: N consecutive healthy checks before we declare recovery.
+    recovery_threshold = int(settings.get("consecutive_healthy_before_recovery", fail_threshold))
+    alert_on_failure = settings.get("alert_on_failure", True)
+    alert_on_recovery = settings.get("alert_on_recovery", True)
 
-    prev_run = history[-2] if len(history) >= 2 else None
     curr_run = history[-1]
 
     for u in curr_run.get("urls", []):
         name, url, healthy = u.get("name"), u.get("url"), u.get("healthy")
-        prev = next((x for x in prev_run.get("urls", [])), None) if prev_run else None
-        prev = next((x for x in (prev_run or {}).get("urls", []) if x.get("name") == name), None) \
-            if prev_run else None
+        slug = _slug(name)
+        marker = _marker(slug)
+        reason = u.get("reason") or u.get("error") or "unhealthy"
 
-        if healthy and prev and not prev.get("healthy") and settings.get("alert_on_recovery", True):
-            if slack_webhook:
-                send_slack(slack_webhook, {"text": "StayAwakeBot Sentinel Alert", "attachments": [{
-                    "color": "#36a64f", "title": f"RECOVERY: {name}", "title_link": url,
-                    "text": f"Recovered at {utc_stamp()}", "footer": f"StayAwakeBot Sentinel | {utc_stamp()}"}]})
-            if token and repo:
-                owner, repo_name = repo.split("/")
-                q = urllib.parse.quote_plus(
-                    f"repo:{owner}/{repo_name} label:stayawakebot-sentinel state:open {name}")
-                res = github_api.request(f"/search/issues?q={q}", token=token)
-                for it in (res or {}).get("items", []):
-                    api_path = it.get("url", "").replace("https://api.github.com", "")
-                    if api_path:
-                        github_api.request(api_path, method="PATCH", token=token, data={"state": "closed"})
+        open_issue = None
+        if owner and repo_name and token:
+            open_issue = github_api.find_issue_by_marker(
+                owner, repo_name, marker, token, labels=LABEL)
 
         if not healthy:
-            if prev and prev.get("alerted"):
+            if not alert_on_failure:
                 continue
             consec = _consecutive_failures(history, name)
-            if consec >= threshold and settings.get("alert_on_failure", True):
-                reason = u.get("error") or "unhealthy"
-                text = (f"DOWN: {name} — {url}\nStatus: {u.get('status_code')} | "
-                        f"Response: {u.get('response_ms')}ms | {reason}")
-                if slack_webhook:
-                    send_slack(slack_webhook, {"text": "StayAwakeBot Sentinel Alert", "attachments": [{
-                        "color": "#ff0000", "title": f"DOWN: {name}", "title_link": url, "text": text,
-                        "footer": f"StayAwakeBot Sentinel | {utc_stamp()}",
-                        "fields": [{"title": "Consecutive failures", "value": str(consec), "short": True}]}]})
-                if token and repo:
-                    owner, repo_name = repo.split("/")
-                    github_api.request(f"/repos/{owner}/{repo_name}/issues", method="POST", token=token, data={
-                        "title": _title("DOWN", name, url),
-                        "body": (f"## StayAwakeBot Sentinel detected an availability issue\n\n"
-                                 f"**URL:** {url}\n**Detected at:** {utc_stamp()}\n"
-                                 f"**Status code:** {u.get('status_code')}\n"
-                                 f"**Response time:** {u.get('response_ms')}ms\n**Reason:** {reason}\n"
-                                 f"**Consecutive failures:** {consec}\n\n"
-                                 f"Auto-opened by StayAwakeBot Sentinel. Will be auto-closed on recovery."),
-                        "labels": ["stayawakebot-sentinel"]})
-                u["alerted"] = True
+            if consec < fail_threshold:
+                continue
+            body = _render_body(name, url, u, history, slug)
 
-    write_json(history_path, history)
+            if owner and repo_name and token:
+                if open_issue is None:
+                    github_api.create_issue(owner, repo_name, _title(name), body,
+                                            token, labels=[LABEL])
+                else:
+                    # Refresh the existing issue in place — no notification.
+                    github_api.update_issue(owner, repo_name, open_issue["number"],
+                                            token, title=_title(name), body=body)
+
+            # Slack only on the DOWN transition (the run it first crosses the threshold).
+            if slack_webhook and consec == fail_threshold:
+                send_slack(slack_webhook, {"text": "StayAwakeBot Sentinel Alert", "attachments": [{
+                    "color": "#ff0000", "title": f"DOWN: {name}", "title_link": url,
+                    "text": f"{reason}\nStatus: {u.get('status_code')} | "
+                            f"Response: {u.get('response_ms')}ms",
+                    "footer": f"StayAwakeBot Sentinel | {utc_stamp()}",
+                    "fields": [{"title": "Consecutive failures", "value": str(consec),
+                                "short": True}]}]})
+
+        else:  # healthy
+            if not alert_on_recovery:
+                continue
+            consec_ok = _consecutive_healthy(history, name)
+            if consec_ok < recovery_threshold:
+                continue   # within the debounce window; not declared recovered yet
+
+            if owner and repo_name and token and open_issue is not None:
+                since = _outage_start(_transitions(history, name))
+                downtime = _humanize(since, u.get("checked_at"))
+                github_api.add_issue_comment(
+                    owner, repo_name, open_issue["number"],
+                    f"\U0001F7E2 **Recovered** at {_fmt_ts(u.get('checked_at'))} "
+                    f"after {downtime}. Closing — the sentinel will reopen a fresh issue "
+                    f"if it goes down again.", token)
+                github_api.update_issue(owner, repo_name, open_issue["number"],
+                                        token, state="closed")
+
+            if slack_webhook and consec_ok == recovery_threshold:
+                send_slack(slack_webhook, {"text": "StayAwakeBot Sentinel Alert", "attachments": [{
+                    "color": "#36a64f", "title": f"RECOVERY: {name}", "title_link": url,
+                    "text": f"Recovered at {utc_stamp()}",
+                    "footer": f"StayAwakeBot Sentinel | {utc_stamp()}"}]})
+
     print("Alerts processed (if any).")

--- a/src/stayawake/bots/health/checker.py
+++ b/src/stayawake/bots/health/checker.py
@@ -24,7 +24,7 @@ async def check_one(session: aiohttp.ClientSession, cfg: UrlCheckConfig) -> dict
         "name": cfg.name, "url": cfg.url, "checked_at": now_iso(),
         "dns_ms": None, "status_code": None, "response_ms": None,
         "redirect_count": 0, "ssl": None, "keyword_found": None,
-        "healthy": False, "error": None, "attempt": 0, "tags": cfg.tags,
+        "healthy": False, "error": None, "reason": None, "attempt": 0, "tags": cfg.tags,
     }
     sp = urlsplit(cfg.url)
     host = sp.hostname
@@ -70,7 +70,31 @@ async def check_one(session: aiohttp.ClientSession, cfg: UrlCheckConfig) -> dict
             result["error"] = f"connection_error: {e}"
         except Exception as e:  # noqa: BLE001
             result["error"] = f"error: {e}"
+    result["reason"] = None if result["healthy"] else _derive_reason(result, cfg)
     return result
+
+
+def _derive_reason(result: dict, cfg: UrlCheckConfig) -> str:
+    """Human-readable explanation of WHY a check is unhealthy (named per failing
+    dimension), so an alert can say 'keyword not found' rather than a bare 'DOWN'."""
+    if result.get("error"):
+        return result["error"]
+    parts: list[str] = []
+    sc = result.get("status_code")
+    if cfg.expected_status is not None and sc is not None and sc != cfg.expected_status:
+        parts.append(f"HTTP {sc} (expected {cfg.expected_status})")
+    rm = result.get("response_ms")
+    if cfg.max_response_ms is not None and rm is not None and rm > cfg.max_response_ms:
+        parts.append(f"slow: {rm}ms > {cfg.max_response_ms}ms")
+    if cfg.keyword is not None and result.get("keyword_found") is False:
+        parts.append(f"keyword '{cfg.keyword}' not found in body")
+    if cfg.check_ssl and cfg.url.lower().startswith("https://"):
+        info = result.get("ssl")
+        if not (isinstance(info, dict) and info.get("valid")):
+            parts.append("TLS certificate invalid or expired")
+    if sc is None and not parts:
+        parts.append("no response")
+    return "; ".join(parts) or "unhealthy"
 
 
 async def run_checks(configs: list[UrlCheckConfig]) -> list[dict]:
@@ -107,6 +131,7 @@ def append_minimal_history(results: list[dict], generated_at: str, reports_dir: 
             "name": r.get("name"), "url": r.get("url"), "dns_ms": r.get("dns_ms"),
             "healthy": bool(r.get("healthy")), "status_code": r.get("status_code"),
             "response_ms": r.get("response_ms"), "error": r.get("error"),
+            "reason": r.get("reason"),
             "checked_at": r.get("checked_at"), "tags": r.get("tags", []), "alerted": False,
         } for r in results],
     })

--- a/src/stayawake/bots/health/reporter.py
+++ b/src/stayawake/bots/health/reporter.py
@@ -87,6 +87,7 @@ def generate(latest_path: str | Path = "reports/latest.json",
         "name": r.get("name"), "url": r.get("url"), "dns_ms": r.get("dns_ms"),
         "healthy": bool(r.get("healthy")), "status_code": r.get("status_code"),
         "response_ms": r.get("response_ms"), "error": r.get("error"),
+        "reason": r.get("reason"),
         "checked_at": r.get("checked_at"), "tags": r.get("tags", []), "alerted": False,
     } for r in results]}
     _upsert_history(history, run_entry, generated_at)

--- a/src/stayawake/core/adapters/github_api.py
+++ b/src/stayawake/core/adapters/github_api.py
@@ -145,6 +145,41 @@ def create_issue(owner: str, repo: str, title: str, body: str, token: str | None
     return request(f"/repos/{owner}/{repo}/issues", method="POST", token=token, data=data)
 
 
+def update_issue(owner: str, repo: str, number: int, token: str | None,
+                 title: str | None = None, body: str | None = None,
+                 state: str | None = None) -> dict | None:
+    """PATCH an existing issue (title/body/state). Editing the body sends NO
+    notification — used to refresh a self-updating status issue silently."""
+    data: dict = {}
+    if title is not None:
+        data["title"] = title
+    if body is not None:
+        data["body"] = body
+    if state is not None:
+        data["state"] = state
+    if not data:
+        return None
+    return request(f"/repos/{owner}/{repo}/issues/{number}", method="PATCH",
+                   token=token, data=data)
+
+
+def add_issue_comment(owner: str, repo: str, number: int, body: str,
+                      token: str | None) -> dict | None:
+    """POST a comment (this DOES notify subscribers — reserve for state changes)."""
+    return request(f"/repos/{owner}/{repo}/issues/{number}/comments", method="POST",
+                   token=token, data={"body": body})
+
+
+def find_issue_by_marker(owner: str, repo: str, marker: str, token: str | None,
+                         labels: str | None = None) -> dict | None:
+    """Find one open issue whose body contains `marker` (a stable hidden tag), so the
+    sentinel can update its single per-project issue regardless of title/status churn."""
+    for it in list_open_issues(owner, repo, token, labels=labels):
+        if marker in (it.get("body") or ""):
+            return it
+    return None
+
+
 def get_branch_protection(owner: str, repo: str, branch: str,
                           token: str | None) -> dict | None:
     """Branch-protection settings for a branch, or None if unprotected/inaccessible.

--- a/tests/bots/health/test_alerter.py
+++ b/tests/bots/health/test_alerter.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Health alerter: single self-updating issue per project — no network."""
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from stayawake.bots.health import alerter   # noqa: E402
+
+SETTINGS = {"settings": {"consecutive_failures_before_alert": 2,
+                         "consecutive_healthy_before_recovery": 2}}
+
+
+def _down(at, reason="HTTP 503 (expected 200)"):
+    return {"name": "A", "url": "https://a", "healthy": False, "reason": reason,
+            "status_code": 503, "response_ms": 100, "dns_ms": 12, "checked_at": at}
+
+
+def _up(at):
+    return {"name": "A", "url": "https://a", "healthy": True, "reason": None,
+            "status_code": 200, "response_ms": 90, "dns_ms": 12, "checked_at": at}
+
+
+def _hist(*runs):
+    return [{"generated_at": f"t{i}", "urls": [u]} for i, u in enumerate(runs)]
+
+
+class _Spy:
+    """Records github_api calls; configurable existing-issue lookup."""
+
+    def __init__(self, existing=None):
+        self.existing = existing
+        self.created = []
+        self.updated = []
+        self.comments = []
+
+    def find_issue_by_marker(self, owner, repo, marker, token, labels=None):
+        return self.existing
+
+    def create_issue(self, owner, repo, title, body, token, labels=None):
+        self.created.append({"title": title, "body": body})
+        return {"number": 99}
+
+    def update_issue(self, owner, repo, number, token, title=None, body=None, state=None):
+        self.updated.append({"number": number, "title": title, "body": body, "state": state})
+        return {"number": number}
+
+    def add_issue_comment(self, owner, repo, number, body, token):
+        self.comments.append({"number": number, "body": body})
+        return {"id": 1}
+
+
+class AlerterTest(unittest.TestCase):
+    def setUp(self):
+        d = Path(tempfile.mkdtemp())
+        self.latest = d / "latest.json"
+        self.history = d / "history.json"
+        self.latest.write_text(json.dumps({"generated_at": "t", "results": []}))
+
+    def _run(self, history, existing=None):
+        self.history.write_text(json.dumps(history))
+        spy = _Spy(existing=existing)
+        with mock.patch.multiple(
+                "stayawake.bots.health.alerter.github_api",
+                find_issue_by_marker=spy.find_issue_by_marker,
+                create_issue=spy.create_issue,
+                update_issue=spy.update_issue,
+                add_issue_comment=spy.add_issue_comment), \
+             mock.patch("stayawake.bots.health.alerter.load_yaml", return_value=SETTINGS), \
+             mock.patch("stayawake.bots.health.alerter.send_slack"), \
+             mock.patch.dict("os.environ",
+                             {"GITHUB_TOKEN": "t", "GITHUB_REPOSITORY": "o/r"}, clear=False):
+            alerter.run(self.latest, self.history)
+        return spy
+
+    def test_creates_one_issue_when_down_and_none_exists(self):
+        spy = self._run(_hist(_down("t1"), _down("t2")), existing=None)
+        self.assertEqual(len(spy.created), 1, "should open exactly one issue")
+        self.assertEqual(spy.updated, [])
+        body = spy.created[0]["body"]
+        self.assertIn("stayawakebot-sentinel:a", body)             # stable marker
+        self.assertIn("HTTP 503 (expected 200)", body)             # failing dimension surfaced
+
+    def test_updates_existing_issue_instead_of_duplicating(self):
+        spy = self._run(_hist(_down("t1"), _down("t2")), existing={"number": 5})
+        self.assertEqual(spy.created, [], "must NOT open a second issue")
+        self.assertEqual(len(spy.updated), 1)
+        self.assertEqual(spy.updated[0]["number"], 5)
+        self.assertIsNone(spy.updated[0]["state"])                 # silent body refresh, not closed
+
+    def test_below_failure_threshold_does_nothing(self):
+        spy = self._run(_hist(_up("t0"), _down("t1")), existing=None)   # only 1 consecutive fail
+        self.assertEqual(spy.created, [])
+        self.assertEqual(spy.updated, [])
+
+    def test_recovery_comments_and_closes_after_debounce(self):
+        spy = self._run(_hist(_down("t0"), _down("t1"), _up("t2"), _up("t3")),
+                        existing={"number": 5})
+        self.assertEqual(len(spy.comments), 1, "should post one recovery comment")
+        self.assertIn("Recovered", spy.comments[0]["body"])
+        self.assertTrue(any(u["state"] == "closed" for u in spy.updated),
+                        "should close the issue on recovery")
+
+    def test_recovery_within_debounce_does_not_close(self):
+        spy = self._run(_hist(_down("t0"), _down("t1"), _up("t2")), existing={"number": 5})
+        self.assertEqual(spy.comments, [], "one healthy check is within the debounce window")
+        self.assertEqual(spy.updated, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## One self-updating issue per project (stop the `[DOWN]` flood)

Closes the root cause behind the ~970 duplicate `[DOWN]` issues: the alerter always `POST`ed a new
issue and only deduped via an `alerted` flag in `history.json` that doesn't survive between CI runs.

**The GitHub issue is now the source of truth**, found by a stable hidden marker
(`<!-- stayawakebot-sentinel:<slug> -->`) rather than the title — so a lost/rebuilt history can't
produce duplicates.

### Behavior
- **One issue per project.** First DOWN opens it; subsequent down runs **refresh the body in place
  silently** (edits don't notify).
- **Comment only on transitions.** A comment is posted on the first DOWN and on recovery — never per run.
- **Close on recovery**, with a configurable `consecutive_healthy_before_recovery` debounce to absorb
  flapping endpoints (defaults to the failure threshold).
- **Names the failing dimension** (status / latency / keyword / TLS) via a new `reason` field —
  previously a keyword/latency/TLS failure showed a bare "DOWN" with no explanation.
- **Compact format:** a status-glance table + a collapsed incident log of recent transitions, so the
  tracker shows only active incidents.

### Rendered issue (example)
> ### 🔴 DOWN — keyword "ok" not found in body
> **https://ndevu-store-be.onrender.com**
>
> | | |
> |---|---|
> | Status | 🔴 Unhealthy since **2026-06-25 09:31 UTC** (3h 27m) |
> | Failing check | keyword "ok" not found in body |
> | HTTP | 200 · 148 ms · DNS 56 ms |
> | Consecutive failures | 1 |
> | Last checked | 2026-06-25 09:31 UTC |
>
> *(+ a collapsed "Incident log" with recent DOWN/Recovered transitions and downtimes)*

### Changes
- `bots/health/alerter.py` — rewritten issue logic (find-by-marker → create/update/close, transition-only comments, debounce, body renderer).
- `bots/health/checker.py` + `reporter.py` — derive and persist the `reason` (failing dimension).
- `core/adapters/github_api.py` — add `update_issue`, `add_issue_comment`, `find_issue_by_marker`.
- Tests: create-once, update-not-duplicate, recovery close-after-debounce (5 new; full suite 99 pass).
- Docs: `CONFIGURATION.md`, `config/urls.yml`, `CHANGELOG.md`.

Design chosen with the maintainer: close-on-recovery · dynamic status title · comment-only-on-transition · per-URL · 2-check recovery debounce.
