### PR TITLE
feat(packaging): support Python 3.11–3.14 (lower floor + CI matrix)

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,11 +1,29 @@
 name: 'Set up StayAwakeBot toolchain'
-description: 'Install Python with a pip cache, then install this repo as a package. Single source of truth for the CI toolchain (the version lives in .python-version).'
+description: 'Install Python with a pip cache, then install this repo as a package. Defaults to .python-version (single source for non-matrix jobs); a caller can override the version, e.g. the CI test matrix.'
 author: 'StayAwakeBot'
+
+inputs:
+  python-version:
+    description: 'Explicit Python version (e.g. a CI matrix minor). When empty, falls back to .python-version.'
+    required: false
+    default: ''
 
 runs:
   using: 'composite'
   steps:
-    - name: Set up Python
+    # Matrix path: a caller (e.g. ci.yml's 3.11–3.14 matrix) requested an explicit minor.
+    - name: Set up Python (explicit version)
+      if: inputs.python-version != ''
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1   # v6.3.0
+      with:
+        python-version: ${{ inputs.python-version }}
+        check-latest: true                      # always fetch the newest patch of that minor
+        cache: 'pip'
+        cache-dependency-path: pyproject.toml
+
+    # Default path: non-matrix jobs (release, sentinels) use the single source of truth.
+    - name: Set up Python (.python-version)
+      if: inputs.python-version == ''
       uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1   # v6.3.0
       with:
         python-version-file: .python-version   # single source for the CI Python version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,12 +24,18 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false   # report every minor's result, not just the first to fail
+      matrix:
+        python-version: ['3.11', '3.12', '3.13', '3.14']   # the supported range (see requires-python)
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0   # v7.0.0
 
       - name: Set up toolchain
         uses: ./.github/actions/setup
+        with:
+          python-version: ${{ matrix.python-version }}
 
       - name: Run test suite
         run: python -m unittest discover -s tests -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ All notable changes to this project are documented here. The format is based on
 - This changelog.
 
 ### Changed
+- **Minimum Python lowered to 3.11** (`requires-python >=3.11`, was `>=3.13`), with a CI test
+  matrix across **3.11–3.14** so the supported range is verified on every push. The code never
+  needed 3.13, so this fixes the confusing `pip install` failure on 3.11/3.12. The published
+  wheel is unchanged (pure-Python — one artifact for every supported version).
 - **Health alerting now keeps one self-updating issue per project** instead of opening a new
   `[DOWN]` issue every run. The GitHub issue is the source of truth (found by a stable hidden
   marker, not a history flag), so a lost/rebuilt history can't produce duplicates: while a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ name = "stayawakebot"
 dynamic = ["version"]
 description = "Distributable monitoring & security sentinel toolkit — uptime checks plus self-propagating-worm detection, remediation, and prevention."
 readme = "README.md"
-requires-python = ">=3.13"
+requires-python = ">=3.11"
 license = "MIT"
 authors = [{ name = "Jean Paul Elisa NIYOKWIZERWA" }]
 keywords = ["monitoring", "uptime", "security", "sentinel", "worm", "supply-chain", "github-actions"]
@@ -18,7 +18,10 @@ classifiers = [
   "Development Status :: 4 - Beta",
   "Intended Audience :: Developers",
   "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Security",
   "Topic :: System :: Monitoring",
 ]


### PR DESCRIPTION
Closes #1037.

## Why
`requires-python >=3.13` made `pip install stayawakebot` fail on Python **3.11/3.12** with a cryptic "No matching distribution found". An audit (syntax + stdlib + dependencies, cross-checked) confirmed the floor was **self-imposed policy, not a real requirement**: the code uses no PEP 695 generics, no 3.12/3.13-only stdlib APIs, `from __future__ import annotations` everywhere, and all deps ship 3.11/3.12 wheels.

## What
- **`requires-python`: `>=3.13` → `>=3.11`** — the one change that actually unblocks 3.11/3.12 (and removes the misleading pip error).
- **Classifiers** advertise `3.11`, `3.12`, `3.13`, `3.14`.
- **CI test matrix `[3.11, 3.12, 3.13, 3.14]`** — there was no matrix before (one job on a single interpreter); this makes the support claim *verified*, not asserted. `fail-fast: false` so every minor reports.
- **Shared `setup` action** gains an optional `python-version` input. The matrix passes each minor; non-matrix callers (release, sentinels) keep using `.python-version` unchanged via the fallback step.

## Deliberate non-changes
- **`.python-version` stays `3.13`** — the matrix is the floor guardrail, and the pure-Python `py3-none-any` wheel is byte-identical regardless of build interpreter, so building/releasing on the floor would be churn for no gain.
- **Docker base stays `python:3.14-slim`** — runtime image, decoupled from the packaging floor (newest = best posture).
- **worm-scan pin stays `3.13`** — still satisfies `>=3.11`; it's self-contained for external adopters.

## Notes
- Ships to users on the **next release tag** (the widened `requires-python` only reaches PyPI via a new version); v0.1.2 stays `>=3.13`.
- The support **policy** + stale-doc reconciliation (`docs/RELEASING.md` still says `>=3.14`) follow in a small docs-only PR.
- Branch protection: `main` isn't protected, so no required-check name to update; if it ever is, the check becomes `test (3.11)` … `test (3.14)`.