### PR TITLE
docs: Python support policy + single PREREQUISITES doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,10 +10,14 @@ pip install -e .
 python -m unittest discover -s tests      # all tests must pass
 ```
 
-**Python version** — the CI toolchain version lives in one place, [`.python-version`](.python-version)
-(read by `actions/setup-python`); the packaged **floor** is `requires-python` in `pyproject.toml`.
-Bump the version there, not in workflow files. (The `worm-scan` action stays pinned
-explicitly so it remains self-contained for repos that adopt the gate.)
+**Python versions** — we support every maintained (non-EOL) CPython minor with real-world
+deployment: currently **3.11–3.14**, tested in CI on each (the `ci.yml` matrix). The policy:
+drop a version the release *after* it reaches upstream end-of-life, and add a new minor once it
+ships — so the matrix evolves on its own. The packaged **floor** is `requires-python` in
+`pyproject.toml`; keep the classifiers and the CI matrix in sync with it. The CI/dev toolchain
+default lives in one place, [`.python-version`](.python-version) (read by `actions/setup-python`) —
+bump it there, not in workflow files. (The `worm-scan` action stays pinned explicitly so it
+remains self-contained for repos that adopt the gate.)
 
 ## Layout (one responsibility per folder)
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,8 @@ ships — so the matrix evolves on its own. The packaged **floor** is `requires-
 `pyproject.toml`; keep the classifiers and the CI matrix in sync with it. The CI/dev toolchain
 default lives in one place, [`.python-version`](.python-version) (read by `actions/setup-python`) —
 bump it there, not in workflow files. (The `worm-scan` action stays pinned explicitly so it
-remains self-contained for repos that adopt the gate.)
+remains self-contained for repos that adopt the gate.) The user-facing version requirement
+lives in [`docs/PREREQUISITES.md`](docs/PREREQUISITES.md).
 
 ## Layout (one responsibility per folder)
 ```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ commit reports back to the repository — the same packaged code in both places.
 
 ## Quick start
 
-Requires **Python 3.11+** (tested on 3.11–3.14).
+> **Prerequisites:** Python 3.11+ — see [docs/PREREQUISITES.md](docs/PREREQUISITES.md).
 
 ```bash
 pip install stayawakebot                                            # from PyPI (released versions)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ commit reports back to the repository — the same packaged code in both places.
 
 ## Quick start
 
+Requires **Python 3.11+** (tested on 3.11–3.14).
+
 ```bash
 pip install stayawakebot                                            # from PyPI (released versions)
 # or the latest from source:

--- a/docs/PREREQUISITES.md
+++ b/docs/PREREQUISITES.md
@@ -1,24 +1,20 @@
 # Prerequisites
 
-The single source of truth for what you need to install and run StayAwakeBot. Other docs link
-here instead of repeating it.
-
 ## Python
 
-StayAwakeBot is a pure-Python package supporting **Python 3.11–3.14**, tested on each in CI.
-Installation requires **Python ≥ 3.11** — there is **no upper bound**, so newer interpreters
-(3.14 and future releases) install and run fine even before they're added to the test matrix.
+You need **Python 3.11 or newer**. The package is built and tested against 3.11, 3.12, 3.13,
+and 3.14, and there's no upper limit — newer releases keep working as they ship.
 
-On an interpreter older than 3.11, `pip install stayawakebot` fails with:
+If `pip install stayawakebot` ends with:
 
 ```
 ERROR: Could not find a version that satisfies the requirement stayawakebot (from versions: none)
 ERROR: No matching distribution found for stayawakebot
 ```
 
-That is pip's (cryptic) way of saying your interpreter is below the floor — not that the package
-is missing. Switch to 3.11+: use your distro's `python3.12` package, or
-`pyenv install 3.12 && pyenv local 3.12`.
+it almost always means your Python is older than 3.11 — pip reports a version mismatch this way
+rather than saying so directly. Install a 3.11+ interpreter (your distribution's `python3.12`
+package, or `pyenv install 3.12`) and try again.
 
 ## Install
 
@@ -26,12 +22,11 @@ is missing. Switch to 3.11+: use your distro's `python3.12` package, or
 pip install stayawakebot          # or: pipx install stayawakebot
 ```
 
-See [USAGE.md](USAGE.md) for the console scripts and configuration.
+The console scripts and configuration are described in [USAGE.md](USAGE.md).
 
-## No local Python? Use the container
+## Running without a local Python
 
-The same tool ships as a digest-pinned, non-root image on GHCR, so Docker is the only
-requirement:
+A prebuilt image is published to GHCR, so Docker alone is enough:
 
 ```bash
 docker run --rm ghcr.io/ndevu12/stayawakebot:latest stayawake-security-scan --help

--- a/docs/PREREQUISITES.md
+++ b/docs/PREREQUISITES.md
@@ -1,0 +1,38 @@
+# Prerequisites
+
+The single source of truth for what you need to install and run StayAwakeBot. Other docs link
+here instead of repeating it.
+
+## Python
+
+StayAwakeBot is a pure-Python package supporting **Python 3.11–3.14**, tested on each in CI.
+Installation requires **Python ≥ 3.11** — there is **no upper bound**, so newer interpreters
+(3.14 and future releases) install and run fine even before they're added to the test matrix.
+
+On an interpreter older than 3.11, `pip install stayawakebot` fails with:
+
+```
+ERROR: Could not find a version that satisfies the requirement stayawakebot (from versions: none)
+ERROR: No matching distribution found for stayawakebot
+```
+
+That is pip's (cryptic) way of saying your interpreter is below the floor — not that the package
+is missing. Switch to 3.11+: use your distro's `python3.12` package, or
+`pyenv install 3.12 && pyenv local 3.12`.
+
+## Install
+
+```bash
+pip install stayawakebot          # or: pipx install stayawakebot
+```
+
+See [USAGE.md](USAGE.md) for the console scripts and configuration.
+
+## No local Python? Use the container
+
+The same tool ships as a digest-pinned, non-root image on GHCR, so Docker is the only
+requirement:
+
+```bash
+docker run --rm ghcr.io/ndevu12/stayawakebot:latest stayawake-security-scan --help
+```

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -59,7 +59,7 @@ the OIDC exchange is rejected.
 2. (Optional but recommended) Dry-run to TestPyPI: Actions → **Release** → *Run workflow*
    (this triggers `workflow_dispatch` → `publish-testpypi`). Then verify in a clean venv:
    ```bash
-   python3.13 -m venv /tmp/v && . /tmp/v/bin/activate
+   python3 -m venv /tmp/v && . /tmp/v/bin/activate   # any supported interpreter (>=3.11)
    # TestPyPI lacks our deps, so allow PyPI as a fallback index:
    pip install --index-url https://test.pypi.org/simple/ \
                --extra-index-url https://pypi.org/simple/ stayawakebot
@@ -119,8 +119,8 @@ than a subpath here.
 ### Scanner-version coupling
 Strix installs the scanner from PyPI via its `version` input (blank = latest; pin in production).
 Bump that pin in lockstep with the moving `v1` tag so the published Action references a known,
-attested release. Note: `stayawakebot 0.1.0` requires Python `>=3.14`, so Strix's `action.yml`
-sets up Python `3.14`; lower it to `3.13` once a release built on the `>=3.13` floor ships.
+attested release. Note: `stayawakebot` requires Python `>=3.11`, so Strix's `action.yml` only
+needs to set up a `>=3.11` interpreter to run the scanner (a newer minor such as 3.14 is fine).
 
 ## Container image (GHCR — P3)
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -5,6 +5,8 @@ The same commands run locally or inside the bundled GitHub Actions workflows.
 
 ## Install
 
+Requires **Python 3.11+** (tested on 3.11–3.14).
+
 ```bash
 pip install stayawakebot                                                          # released versions, from PyPI
 pip install "stayawakebot @ git+https://github.com/Ndevu12/stayAwakeBot@main"     # latest from source (or pipx install "…")

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -5,7 +5,7 @@ The same commands run locally or inside the bundled GitHub Actions workflows.
 
 ## Install
 
-Requires **Python 3.11+** (tested on 3.11–3.14).
+Requires Python 3.11+ — see [Prerequisites](PREREQUISITES.md).
 
 ```bash
 pip install stayawakebot                                                          # released versions, from PyPI


### PR DESCRIPTION
Companion to #1043 (the floor + CI matrix). Docs-only; concise, single-sourced.

## What
- **New `docs/PREREQUISITES.md`** — the single source of truth for what you need to install/run: supported Python (**3.11–3.14**, `>=3.11` floor, **no upper bound**), the cryptic-below-floor pip error explained, install command, and the Docker alternative.
- **README / `docs/USAGE.md`** — replaced the duplicated "Requires Python 3.11+" lines with a one-line **link** to `PREREQUISITES.md`, so the version requirement isn't copy-pasted across files.
- **`CONTRIBUTING.md`** — documents the maintainer **support policy** (every maintained non-EOL CPython minor with real deployment; drop on EOL, add on release; keep `requires-python`/classifiers/matrix in sync) and links to `PREREQUISITES.md` for the user-facing requirement.
- **`docs/RELEASING.md`** — fixed the stale `>=3.14 → lower to 3.13` note (now `>=3.11`) and the hard-coded `python3.13` venv example.

## Notes
- Disjoint files from #1043 → no conflict; merge **#1043 first** so the docs don't briefly describe an unshipped floor.
- The Docker base (`3.14-slim`) and `worm-scan` `3.13` pin are intentional runtime/pin choices, not floor claims, so they're untouched.