### PR TITLE
chore(deps): drop unused typing-extensions dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ classifiers = [
 dependencies = [
   "aiohttp",
   "pyyaml",
-  "typing-extensions",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
`typing-extensions` is declared in `[project.dependencies]` but **never imported** anywhere in `src/` or `tests/` (verified: zero `typing_extensions` references — the codebase uses `from __future__ import annotations`, so it needs no typing back-ports). Dropping it trims the install footprint with no behavior change.

- Pure removal of one line from `dependencies`; the package is still pure-Python.
- If a transitive dependency happens to need `typing-extensions`, pip still pulls it; we just no longer declare a direct dependency we don't use.
- Verified by the 3.11–3.14 CI matrix (full suite) on this PR.