### PR TITLE
fix(security): don't crash a scan when the reports dir is unwritable (#1038)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,15 @@ All notable changes to this project are documented here. The format is based on
 - `hatch-vcs` now derives the version only from `vX.Y.Z` tags (`git_describe_command` match),
   so the moving Marketplace major tag (`v1`) cannot be mistaken for the package version.
 
+### Fixed
+- **Report writing no longer crashes a completed scan when the reports directory is
+  unwritable** (read-only filesystem or a bind-mount owned by another user — e.g. the
+  documented `docker run -v "$PWD:/repo:ro" …` as the image's non-root user). A scan's
+  verdict is its exit code; report persistence is best-effort, so an unwritable directory now
+  prints a warning and falls back to a temp dir instead of raising. The container also
+  defaults reports to a writable path (`STAYAWAKE_REPORTS_DIR`), and the docs show a
+  `--user "$(id -u):$(id -g)"` invocation for writing the report back to the host.
+
 ## [0.1.0] - Unreleased
 
 Initial public release: Health sentinel (uptime monitoring) and Security sentinel

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,9 +60,20 @@ RUN pip install --no-cache-dir /tmp/*.whl && rm -f /tmp/*.whl
 
 WORKDIR /repo
 
+# Default reports to a container-internal path the runtime user can always write — a host
+# bind-mount (e.g. -v "$PWD:/repo:ro") is owned by the host uid and isn't writable by
+# `sentinel`, so the verdict (exit code) shouldn't depend on persisting a report there.
+# Override with --reports-dir or this var; report writing also degrades gracefully if the
+# chosen dir turns out unwritable.
+ENV STAYAWAKE_REPORTS_DIR=/tmp/stayawake
+
 # Mount the repository to scan at /repo (read-only is fine for scanning), e.g.:
 #   docker run --rm -v "$PWD:/repo:ro" ghcr.io/ndevu12/stayawakebot \
 #     stayawake-security-scan --local-only --fail-on-findings
+# To keep the report on the host, mount a writable dir and run as your own uid so the
+# bind-mount is writable:
+#   docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/repo" \
+#     ghcr.io/ndevu12/stayawakebot stayawake-security-scan --local-only --reports-dir /repo/reports
 # The package ships several console scripts, so there is no single ENTRYPOINT — name the
 # command you want. A bare `docker run` prints the security scanner's help.
 CMD ["stayawake-security-scan", "--help"]

--- a/README.md
+++ b/README.md
@@ -62,6 +62,15 @@ docker run --rm -v "$PWD:/repo:ro" ghcr.io/ndevu12/stayawakebot \
   stayawake-security-scan --local-only --fail-on-findings
 ```
 
+The exit code is the verdict (`0` clean, `1` findings). To keep the report file too, mount a
+writable dir and run as your own user so the bind-mount is writable:
+
+```bash
+docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/repo" \
+  ghcr.io/ndevu12/stayawakebot \
+  stayawake-security-scan --local-only --reports-dir /repo/reports
+```
+
 Tags: `:latest`, `:X.Y.Z`, `:X.Y`, and `:sha-<commit>`. The image runs as a non-root user, is
 built from the same wheel published to PyPI, and ships SLSA provenance + SBOM attestations.
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -29,6 +29,17 @@ docker run --rm -v "$PWD:/repo:ro" ghcr.io/ndevu12/stayawakebot \
 docker run --rm ghcr.io/ndevu12/stayawakebot stayawake-health-check --help
 ```
 
+The container runs as a non-root user, so a host bind-mount isn't writable by it: the scan's
+verdict is its **exit code** (`0`/`1`), and by default the report is written to a container
+path (`STAYAWAKE_REPORTS_DIR`, `/tmp/stayawake` in the image) rather than the read-only mount.
+To keep the report on the host, mount a writable dir and run as your own user:
+
+```bash
+docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/repo" \
+  ghcr.io/ndevu12/stayawakebot \
+  stayawake-security-scan --local-only --reports-dir /repo/reports
+```
+
 Pin a version (`ghcr.io/ndevu12/stayawakebot:0.1.0`) or a commit (`:sha-<commit>`) for
 reproducibility; `:latest` tracks the newest release. To build it yourself:
 

--- a/src/stayawake/bots/health/reporter.py
+++ b/src/stayawake/bots/health/reporter.py
@@ -5,10 +5,11 @@ Single responsibility: transform `latest.json` into human/machine reports.
 """
 from __future__ import annotations
 
+import os
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
 
-from stayawake.core.io import read_json, write_json
+from stayawake.core.io import read_json, write_json, resolve_writable_dir
 
 
 def compute_uptime(url_name: str, history: list, cutoff: datetime) -> float:
@@ -71,12 +72,14 @@ def _build_markdown(dt: datetime, results: list, healthy: int, avg_resp, status:
 
 
 def generate(latest_path: str | Path = "reports/latest.json",
-             reports_dir: str | Path = "reports") -> None:
+             reports_dir: str | Path | None = None) -> None:
     latest = read_json(latest_path)
     if latest is None:
         print("latest.json not found; run checker first")
         return
-    reports_dir = Path(reports_dir)
+    reports_dir = resolve_writable_dir(
+        reports_dir or os.environ.get("STAYAWAKE_REPORTS_DIR") or "reports",
+        label="health reports")
     results = latest.get("results", [])
     generated_at = latest.get("generated_at")
 

--- a/src/stayawake/bots/health/service.py
+++ b/src/stayawake/bots/health/service.py
@@ -7,11 +7,12 @@ no detection/formatting logic of their own.
 from __future__ import annotations
 
 import asyncio
+import os
 from pathlib import Path
 
 from stayawake.bots.health import checker, reporter, alerter
 from stayawake.bots.health.config import load_config
-from stayawake.core.io import write_json
+from stayawake.core.io import write_json, resolve_writable_dir
 
 REPORTS_DIR = Path("reports")
 
@@ -20,9 +21,10 @@ async def _check_async(config_path: str, reports_dir: str | Path | None = None) 
     settings, configs = load_config(config_path)
     results = await checker.run_checks(configs)
     payload = checker.build_latest_payload(results)
-    # Precedence: explicit arg / --reports-dir → settings.reports_dir → default.
-    rdir = Path(reports_dir or settings.get("reports_dir") or REPORTS_DIR)
-    rdir.mkdir(parents=True, exist_ok=True)
+    # Precedence: explicit arg / --reports-dir → STAYAWAKE_REPORTS_DIR env → settings → default.
+    rdir = Path(reports_dir or os.environ.get("STAYAWAKE_REPORTS_DIR")
+                or settings.get("reports_dir") or REPORTS_DIR)
+    rdir = resolve_writable_dir(rdir, label="health reports")
     write_json(rdir / "latest.json", payload)
     checker.append_minimal_history(results, payload["generated_at"], rdir)
     any_unhealthy = False

--- a/src/stayawake/bots/security/reporter.py
+++ b/src/stayawake/bots/security/reporter.py
@@ -6,13 +6,14 @@ a trimmed machine-readable status, mirroring the availability split.
 """
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
-from stayawake.core.io import read_json, write_json
+from stayawake.core.io import read_json, write_json, resolve_writable_dir
 
 
 def generate(latest_path: str | Path = "reports/security/latest.json",
-             reports_dir: str | Path = "reports/security") -> None:
+             reports_dir: str | Path | None = None) -> None:
     latest = read_json(latest_path)
     if latest is None:
         print("security latest.json not found; run the scanner first")
@@ -27,6 +28,9 @@ def generate(latest_path: str | Path = "reports/security/latest.json",
             for r in latest.get("results", []) if r.get("infected")
         ],
     }
-    write_json(Path(reports_dir) / "status.json", status)
+    rdir = resolve_writable_dir(
+        reports_dir or os.environ.get("STAYAWAKE_REPORTS_DIR") or "reports/security",
+        label="security reports")
+    write_json(rdir / "status.json", status)
     print(f"Security status updated ({summary.get('infected', 0)} infected, "
           f"{summary.get('findings', 0)} findings).")

--- a/src/stayawake/bots/security/service.py
+++ b/src/stayawake/bots/security/service.py
@@ -11,7 +11,7 @@ import os
 from pathlib import Path
 
 from stayawake.core.config import load_yaml
-from stayawake.core.io import write_json
+from stayawake.core.io import write_json, resolve_writable_dir
 from stayawake.core.timeutil import now_iso
 from stayawake.core.adapters import github_api
 from stayawake.core import auth
@@ -128,9 +128,11 @@ def scan(config_path: str | None = None, local_only: bool = False,
     opts = _options(settings)
     sigs = load_signatures(settings.get("signatures_path"))
     allowlist = cfg.get("allowlist", [])
-    # Where reports are written. Override (CLI --reports-dir / settings.reports_dir / arg)
-    # so tests and ad-hoc runs never clobber the repo's committed reports.
-    rdir = Path(reports_dir or settings.get("reports_dir") or REPORTS_DIR)
+    # Where reports are written. Precedence: --reports-dir / arg → STAYAWAKE_REPORTS_DIR env
+    # (used by the container image) → settings.reports_dir → default. Writability is resolved
+    # at write time so an unwritable choice degrades instead of crashing the scan.
+    rdir = Path(reports_dir or os.environ.get("STAYAWAKE_REPORTS_DIR")
+                or settings.get("reports_dir") or REPORTS_DIR)
 
     # --- resolve WHAT to scan (targets are orthogonal to auth: local needs no token) --
     cfg_targets = cfg.get("targets", {}) or {}
@@ -186,7 +188,7 @@ def scan(config_path: str | None = None, local_only: bool = False,
         "any_infected": any(r.infected for r in results),
         "results": [r.to_dict() for r in results],
     }
-    rdir.mkdir(parents=True, exist_ok=True)
+    rdir = resolve_writable_dir(rdir, label="security reports")
     write_json(rdir / "latest.json", payload)
     (rdir / "latest.md").write_text(_render_markdown(payload), encoding="utf-8")
 

--- a/src/stayawake/core/io.py
+++ b/src/stayawake/core/io.py
@@ -4,9 +4,42 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 import tempfile
 from pathlib import Path
 from typing import Any
+
+
+def resolve_writable_dir(preferred: str | Path, *, label: str = "reports") -> Path:
+    """Return a directory we can actually write into, preferring `preferred`.
+
+    Report persistence is best-effort: a CI gate's verdict is its exit code, so a scan that
+    completed must never crash because it couldn't save its report. This tries `preferred`,
+    then a shared temp dir, confirming each with a real write probe — a directory can exist
+    yet be unwritable for the current user (e.g. a host bind-mount under a non-root container
+    user), which `mkdir(exist_ok=True)` alone wouldn't catch. On a fallback it warns once on
+    stderr (naming both paths) and never raises.
+    """
+    preferred = Path(preferred)
+    for candidate in (preferred, Path(tempfile.gettempdir()) / "stayawake-reports"):
+        try:
+            candidate.mkdir(parents=True, exist_ok=True)
+            # mkdir(exist_ok=True) succeeds on a dir owned by another uid; prove we can
+            # actually create a file before trusting it.
+            fd, probe = tempfile.mkstemp(dir=str(candidate), prefix=".probe-")
+            os.close(fd)
+            os.remove(probe)
+        except OSError:
+            continue
+        if candidate != preferred:
+            print(f"warning: {label} directory {preferred} is not writable; "
+                  f"writing to {candidate} instead", file=sys.stderr)
+        return candidate
+    # Last resort: a unique, current-user-owned dir (always writable, never collides).
+    last = Path(tempfile.mkdtemp(prefix="stayawake-reports-"))
+    print(f"warning: {label} directory {preferred} is not writable; "
+          f"writing to {last} instead", file=sys.stderr)
+    return last
 
 
 def read_json(path: str | Path, default: Any = None) -> Any:

--- a/tests/core/test_io.py
+++ b/tests/core/test_io.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""resolve_writable_dir: report writing must degrade gracefully on an unwritable dir,
+never crash a completed run."""
+from __future__ import annotations
+
+import contextlib
+import io as _io
+import tempfile
+import unittest
+from pathlib import Path
+
+from stayawake.core.io import resolve_writable_dir, write_json
+
+
+class TestResolveWritableDir(unittest.TestCase):
+    def test_writable_preferred_is_used_silently(self):
+        with tempfile.TemporaryDirectory() as d:
+            target = Path(d) / "reports" / "security"
+            err = _io.StringIO()
+            with contextlib.redirect_stderr(err):
+                got = resolve_writable_dir(target, label="security reports")
+            self.assertEqual(got, target)
+            self.assertTrue(got.is_dir())
+            self.assertEqual(err.getvalue(), "")            # no warning on the happy path
+
+    def test_unwritable_preferred_falls_back_and_warns(self):
+        # Force an unwritable preferred path in a uid-independent way: make its parent a
+        # regular FILE so mkdir raises NotADirectoryError for any user — unlike chmod, which
+        # root ignores (and CI/test runners are often root).
+        with tempfile.TemporaryDirectory() as d:
+            blocker = Path(d) / "blocker"
+            blocker.write_text("not a dir\n")
+            target = blocker / "security"               # parent is a file -> mkdir fails
+            err = _io.StringIO()
+            with contextlib.redirect_stderr(err):
+                got = resolve_writable_dir(target, label="security reports")
+            self.assertNotEqual(got, target)
+            self.assertTrue(got.is_dir())
+            warning = err.getvalue()
+            self.assertIn("not writable", warning)          # warned…
+            self.assertIn(str(target), warning)             # …naming the path we couldn't use
+            # and the fallback is genuinely writable
+            write_json(got / "latest.json", {"ok": True})
+            self.assertTrue((got / "latest.json").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1038.

## Problem
`stayawake-security-scan` completes the scan, then **throws an unhandled traceback while writing its report** whenever the reports dir isn't writable. Two distinct failure points (so guarding only `mkdir` isn't enough):
- **read-only fs** → `rdir.mkdir(...)` raises `OSError [Errno 30]`;
- **bind-mount owned by another uid** → `mkdir(exist_ok=True)` *succeeds*, then `mkstemp`/write raises `PermissionError [Errno 13]`.

This bites the project's own documented Docker command (`docker run -v "$PWD:/repo:ro" …`): the image's non-root `sentinel` user can't write a host bind-mount.

## Fix
A CI gate's contract is its **exit code**; report persistence is best-effort and must never crash a completed scan.

- **`core/io.py`: `resolve_writable_dir(preferred)`** — ensures a dir exists *and* is writable via a real write **probe** (catches the owned-by-another-uid case `mkdir` misses), else falls back to a temp dir with a one-line stderr warning. Never raises.
- Applied at **all four report-write entry points** (security scan + report, health check + report), so the whole class degrades, not just the one site the issue named. Remediation/askpass writes are deliberately **untouched** — those do real work and must still fail loudly.
- **`STAYAWAKE_REPORTS_DIR`** honored (precedence `--reports-dir` > env > config > default); the **Docker image** sets it to `/tmp/stayawake` so the documented read-only command works with no `--reports-dir` and no warning.
- **Docs** (README, USAGE, Dockerfile): the exit code is the verdict, plus a `--user "$(id -u):$(id -g)"` invocation to write the report back to the host.

## Verification
- Unit: `tests/core/test_io.py` — uid-independent regression (forces an unwritable dir via a *file-as-parent* → `NotADirectoryError`, which root can't bypass, unlike `chmod`); asserts fallback + warning, not a crash. Full suite **101 pass**.
- On the built image:
  - documented `:ro` command → exit 0, **no traceback**;
  - reports forced onto the `:ro` mount → `…not writable; writing to /tmp/stayawake-reports instead`, **no traceback**;
  - `--user … -v "$PWD:/repo:ro" -v <host>:/out --reports-dir /out` → `latest.json`+`latest.md` written back to the host.

## Acceptance criteria
- ✅ Documented `:ro` command exits by verdict and doesn't traceback, even with no `--reports-dir`.
- ✅ Unwritable reports dir → warning + correct exit code (regression test added).
- ✅ Docs show a command that works out of the box.