### PR TITLE
refactor(reports): consolidate reports-dir resolution into one shared helper

### DIFF
--- a/src/stayawake/bots/health/reporter.py
+++ b/src/stayawake/bots/health/reporter.py
@@ -5,11 +5,10 @@ Single responsibility: transform `latest.json` into human/machine reports.
 """
 from __future__ import annotations
 
-import os
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
 
-from stayawake.core.io import read_json, write_json, resolve_writable_dir
+from stayawake.core.io import read_json, write_json, resolve_reports_dir
 
 
 def compute_uptime(url_name: str, history: list, cutoff: datetime) -> float:
@@ -77,9 +76,8 @@ def generate(latest_path: str | Path = "reports/latest.json",
     if latest is None:
         print("latest.json not found; run checker first")
         return
-    reports_dir = resolve_writable_dir(
-        reports_dir or os.environ.get("STAYAWAKE_REPORTS_DIR") or "reports",
-        label="health reports")
+    reports_dir = resolve_reports_dir(reports_dir, default="reports",
+                                      label="health reports")
     results = latest.get("results", [])
     generated_at = latest.get("generated_at")
 

--- a/src/stayawake/bots/health/service.py
+++ b/src/stayawake/bots/health/service.py
@@ -7,12 +7,11 @@ no detection/formatting logic of their own.
 from __future__ import annotations
 
 import asyncio
-import os
 from pathlib import Path
 
 from stayawake.bots.health import checker, reporter, alerter
 from stayawake.bots.health.config import load_config
-from stayawake.core.io import write_json, resolve_writable_dir
+from stayawake.core.io import write_json, resolve_reports_dir
 
 REPORTS_DIR = Path("reports")
 
@@ -21,10 +20,8 @@ async def _check_async(config_path: str, reports_dir: str | Path | None = None) 
     settings, configs = load_config(config_path)
     results = await checker.run_checks(configs)
     payload = checker.build_latest_payload(results)
-    # Precedence: explicit arg / --reports-dir → STAYAWAKE_REPORTS_DIR env → settings → default.
-    rdir = Path(reports_dir or os.environ.get("STAYAWAKE_REPORTS_DIR")
-                or settings.get("reports_dir") or REPORTS_DIR)
-    rdir = resolve_writable_dir(rdir, label="health reports")
+    rdir = resolve_reports_dir(reports_dir, settings_value=settings.get("reports_dir"),
+                               default=REPORTS_DIR, label="health reports")
     write_json(rdir / "latest.json", payload)
     checker.append_minimal_history(results, payload["generated_at"], rdir)
     any_unhealthy = False

--- a/src/stayawake/bots/security/reporter.py
+++ b/src/stayawake/bots/security/reporter.py
@@ -6,10 +6,9 @@ a trimmed machine-readable status, mirroring the availability split.
 """
 from __future__ import annotations
 
-import os
 from pathlib import Path
 
-from stayawake.core.io import read_json, write_json, resolve_writable_dir
+from stayawake.core.io import read_json, write_json, resolve_reports_dir
 
 
 def generate(latest_path: str | Path = "reports/security/latest.json",
@@ -28,9 +27,8 @@ def generate(latest_path: str | Path = "reports/security/latest.json",
             for r in latest.get("results", []) if r.get("infected")
         ],
     }
-    rdir = resolve_writable_dir(
-        reports_dir or os.environ.get("STAYAWAKE_REPORTS_DIR") or "reports/security",
-        label="security reports")
+    rdir = resolve_reports_dir(reports_dir, default="reports/security",
+                               label="security reports")
     write_json(rdir / "status.json", status)
     print(f"Security status updated ({summary.get('infected', 0)} infected, "
           f"{summary.get('findings', 0)} findings).")

--- a/src/stayawake/bots/security/service.py
+++ b/src/stayawake/bots/security/service.py
@@ -11,7 +11,7 @@ import os
 from pathlib import Path
 
 from stayawake.core.config import load_yaml
-from stayawake.core.io import write_json, resolve_writable_dir
+from stayawake.core.io import write_json, resolve_reports_dir
 from stayawake.core.timeutil import now_iso
 from stayawake.core.adapters import github_api
 from stayawake.core import auth
@@ -128,11 +128,6 @@ def scan(config_path: str | None = None, local_only: bool = False,
     opts = _options(settings)
     sigs = load_signatures(settings.get("signatures_path"))
     allowlist = cfg.get("allowlist", [])
-    # Where reports are written. Precedence: --reports-dir / arg → STAYAWAKE_REPORTS_DIR env
-    # (used by the container image) → settings.reports_dir → default. Writability is resolved
-    # at write time so an unwritable choice degrades instead of crashing the scan.
-    rdir = Path(reports_dir or os.environ.get("STAYAWAKE_REPORTS_DIR")
-                or settings.get("reports_dir") or REPORTS_DIR)
 
     # --- resolve WHAT to scan (targets are orthogonal to auth: local needs no token) --
     cfg_targets = cfg.get("targets", {}) or {}
@@ -188,7 +183,8 @@ def scan(config_path: str | None = None, local_only: bool = False,
         "any_infected": any(r.infected for r in results),
         "results": [r.to_dict() for r in results],
     }
-    rdir = resolve_writable_dir(rdir, label="security reports")
+    rdir = resolve_reports_dir(reports_dir, settings_value=settings.get("reports_dir"),
+                               default=REPORTS_DIR, label="security reports")
     write_json(rdir / "latest.json", payload)
     (rdir / "latest.md").write_text(_render_markdown(payload), encoding="utf-8")
 

--- a/src/stayawake/core/io.py
+++ b/src/stayawake/core/io.py
@@ -42,6 +42,21 @@ def resolve_writable_dir(preferred: str | Path, *, label: str = "reports") -> Pa
     return last
 
 
+def resolve_reports_dir(explicit: str | Path | None = None, *,
+                        settings_value: str | Path | None = None,
+                        default: str | Path, label: str = "reports") -> Path:
+    """Choose where reports go and make sure it's writable — one place for the precedence
+    so the report writers don't each re-implement it.
+
+    Precedence: `explicit` (a `--reports-dir` / call arg) → `STAYAWAKE_REPORTS_DIR` (the
+    container image sets this to a writable, container-owned path) → `settings.reports_dir`
+    → `default`. The chosen dir is then passed through `resolve_writable_dir`, so an
+    unwritable choice falls back to a temp dir instead of crashing a completed run.
+    """
+    chosen = explicit or os.environ.get("STAYAWAKE_REPORTS_DIR") or settings_value or default
+    return resolve_writable_dir(chosen, label=label)
+
+
 def read_json(path: str | Path, default: Any = None) -> Any:
     p = Path(path)
     if not p.exists():

--- a/tests/core/test_io.py
+++ b/tests/core/test_io.py
@@ -8,8 +8,9 @@ import io as _io
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
-from stayawake.core.io import resolve_writable_dir, write_json
+from stayawake.core.io import resolve_writable_dir, resolve_reports_dir, write_json
 
 
 class TestResolveWritableDir(unittest.TestCase):
@@ -42,6 +43,41 @@ class TestResolveWritableDir(unittest.TestCase):
             # and the fallback is genuinely writable
             write_json(got / "latest.json", {"ok": True})
             self.assertTrue((got / "latest.json").exists())
+
+
+class TestResolveReportsDir(unittest.TestCase):
+    """Shared precedence: explicit → STAYAWAKE_REPORTS_DIR env → settings → default
+    (then made writable via resolve_writable_dir). One place so the report writers
+    don't each re-implement it."""
+
+    def _resolve(self, *, explicit=None, env=None, settings_value=None, default="def"):
+        # Every candidate lives under one writable temp dir, so the result equals whichever
+        # candidate won the precedence (no fallback) — we're asserting precedence, not
+        # writability. STAYAWAKE_REPORTS_DIR is forced to exactly `env` (or absent).
+        with tempfile.TemporaryDirectory() as d:
+            under = lambda name: str(Path(d) / name) if name else None
+            environ = {"STAYAWAKE_REPORTS_DIR": under(env)} if env else {}
+            with mock.patch.dict("os.environ", environ, clear=True):
+                got = resolve_reports_dir(explicit=under(explicit),
+                                          settings_value=under(settings_value),
+                                          default=under(default))
+            return Path(d), got
+
+    def test_explicit_wins(self):
+        base, got = self._resolve(explicit="cli", env="envd", settings_value="cfg")
+        self.assertEqual(got, base / "cli")
+
+    def test_env_beats_settings_and_default(self):
+        base, got = self._resolve(env="envd", settings_value="cfg")
+        self.assertEqual(got, base / "envd")
+
+    def test_settings_beats_default(self):
+        base, got = self._resolve(settings_value="cfg")
+        self.assertEqual(got, base / "cfg")
+
+    def test_default_when_nothing_set(self):
+        base, got = self._resolve()
+        self.assertEqual(got, base / "def")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow-up cleanup to the report-write resilience fix (shipped via #1047, live in v0.1.3). Replaces #1048 (which was closed and couldn't be reopened after its branch was rebased onto current `main`).

## What
The *resilience* (`resolve_writable_dir`) already lives in `core/io.py`, but the **precedence** for choosing the reports dir — `--reports-dir`/arg → `STAYAWAKE_REPORTS_DIR` env → `settings.reports_dir` → default — was copy-pasted into all four report writers (security scan + report, health check + report).

- Add **`resolve_reports_dir(explicit, *, settings_value, default, label)`** to `core/io.py` as the single home for that precedence; it delegates to `resolve_writable_dir` for the unwritable-dir fallback.
- Collapse each writer to a one-line call; drop the now-dead `import os` from the three files that only used it for the env lookup.
- Behavior unchanged; adds precedence unit tests (explicit > env > settings > default).

## Verification
Full suite **105 pass** locally (101 + 4 new precedence tests). Based on current `main`, so no conflicts.