### PR TITLE
feat(cli): add unified terse security CLI `saw`

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -14,7 +14,8 @@ src/stayawake/                     ← single import root (installable; no name 
       matchers/  base · content · filename · structural · heuristic · git_history  # one technique/file
       targets/   base · local · remote
       data/      signatures.yml      # default IoC DB shipped INSIDE the package
-      cli/       scan · report · alert · remediate
+      cli/       scan · report · alert · remediate    # legacy per-bot scripts (frozen, used by CI)
+  cli/         dispatch · _meta · commands/{scan,run,report,alert,fix,audit,…}   # unified `saw` CLI
 pyproject.toml   packaging: metadata · console scripts · package-data
 config/   urls.yml · security.yml        # deployment config (targets/allowlist; signatures are packaged)
 tests/    bots/health · bots/security    # mirrors src
@@ -23,6 +24,7 @@ docs/  prevent/  reports/  .github/  CONTRIBUTING.md
 
 ## Principles
 - **SRP** — `core` (utilities) · `bots/*` (each bot) · `cli/` (entrypoints) · `data/` (signatures) are separate.
+- **Unified CLI** — the top-level `stayawake.cli` package is the terse, security-only `saw` (and `stayawake`) command; one module per verb under `cli/commands/`, each routing to the **same** `bots/security` service the legacy `stayawake-security-*` scripts call. The legacy per-bot `cli/` scripts stay frozen (CI/Docker depend on them); health remains remote-only. See [CLI command guide](CLI.md).
 - **DRY** — `core` (+ `core/adapters`) is reused by both bots; console scripts reuse the thin `main()`s; one packaged signature source.
 - **Reusability / distributability** — `pip install stayawakebot` gives a self-contained scanner with console commands; the worm-scan Action installs it instead of cloning.
 - **Maintainability / collaboration** — standard modern `src/` layout, `pyproject.toml` single source of truth, `CONTRIBUTING.md`, tests mirror `src`, importable without path tricks.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,0 +1,341 @@
+# StayAwakeBot — `saw` CLI command guide
+
+`saw` is StayAwakeBot's local **security** command-line tool — a supply-chain worm hunter you
+run on your own machine to detect, report, and auto-remediate self-propagating malware
+(obfuscated loaders, fake fonts, VS Code auto-run tasks, and stealth "evil merges").
+
+> **Status: implemented; available from source. PyPI release pending.**
+> The `saw` CLI is implemented (`stayawake.cli`) and works when you install from source (or
+> editable, `pip install -e .`). It is **not in a tagged PyPI release yet**, so
+> `pip install stayawakebot` from PyPI does not include it until the next release. The legacy
+> `stayawake-security-*` scripts keep working everywhere — see [Migrating from the legacy
+> scripts](#migrating-from-the-legacy-scripts).
+
+## Contents
+
+- [Overview](#overview)
+- [Install](#install)
+- [Synopsis](#synopsis)
+- [Global options](#global-options)
+- [Commands](#commands)
+  - [`saw scan`](#saw-scan) · [`saw run`](#saw-run) · [`saw report`](#saw-report) ·
+    [`saw alert`](#saw-alert) · [`saw fix`](#saw-fix) · [`saw audit`](#saw-audit) ·
+    [`saw search`](#saw-search) · [`saw doctor`](#saw-doctor) · [`saw completion`](#saw-completion)
+- [Exit codes](#exit-codes)
+- [Shell completion](#shell-completion)
+- [Migrating from the legacy scripts](#migrating-from-the-legacy-scripts)
+- [Compatibility & support](#compatibility--support)
+- [Appendix: design rationale](#appendix-design-rationale)
+
+## Overview
+
+- **`saw` is security-only by design.** It exposes the supply-chain worm hunter for local use.
+- **The health (uptime) bot is not part of this CLI.** It runs remotely-only (a GitHub Actions
+  `*/5` cron) via its own `stayawake-health-*` console scripts; those are unaffected by `saw`.
+- **One scanner, two surfaces.** The same engine runs locally as `saw` and in CI as the
+  published `strix` GitHub Action. How the names relate:
+
+  ```text
+  stayawakebot   the product / PyPI distribution        (pip install stayawakebot)
+  strix          the remote CI gate / GitHub Action      (uses: Ndevu12/strix@<sha>)
+  saw            the local worm hunter / this CLI         (+ `stayawake` long alias)
+  ```
+
+## Install
+
+```bash
+pip install stayawakebot          # from PyPI
+# or the latest from source:
+pip install "stayawakebot @ git+https://github.com/Ndevu12/stayAwakeBot@main"
+```
+
+Installing provides two equivalent binaries:
+
+- **`saw`** — the short everyday command used throughout this guide.
+- **`stayawake`** — an identical, collision-proof long alias. Prefer it in scripts/CI where a
+  3-letter name might clash with another tool on `PATH`.
+
+Verify your install with [`saw doctor`](#saw-doctor).
+
+## Synopsis
+
+```text
+saw <command> [options] [PATHS...]
+```
+
+`saw` with no command prints help. Every command supports `-h/--help`, which documents that
+command's options.
+
+## Global options
+
+Available on `saw` itself:
+
+| Option | Description |
+| --- | --- |
+| `-h`, `--help` | Show help for `saw` or any command. |
+| `--version` | Print the package version and a capability inventory (`security: local + CI; health: CI-only`). |
+
+A few flags recur across commands but are **not** universal — they only exist where they mean
+something:
+
+| Option | Where | Description |
+| --- | --- | --- |
+| `-f`, `--fail` | `scan`, `run`, `audit` | Exit non-zero if the command found something actionable (findings or issues). The single unified gate flag for CI. Replaces the legacy `--fail-on-findings` / `--fail-on-issues`, which still parse. |
+| `--json` | `doctor`, `search` | Emit machine-readable JSON instead of human-formatted output. |
+| `-q`, `--quiet` | `doctor`, `search` | Print only the essentials (problems / command names). |
+
+> Broader `--json` / `-q` coverage on the scan/report/fix commands is planned but not yet wired —
+> those forward to the existing report writers, which today emit human text and JSON report
+> *files* (not stdout JSON).
+
+## Commands
+
+### `saw scan`
+
+Hunt for supply-chain worms across one or more repositories or directories.
+
+```text
+saw scan [PATHS...] [-L] [-c FILE] [-p PATH] [-d DIR] [-f]
+```
+
+| Option | Description |
+| --- | --- |
+| `PATHS...` | Repo or directory paths to scan (ad-hoc, local). If omitted and nothing is configured, scans the current repository. |
+| `-p`, `--path PATH` | Additional path to scan (repeatable); same effect as a positional path. |
+| `-c`, `--config FILE` | Config file (default: `config/security.yml` when present). |
+| `-L`, `--local` | Skip remote GitHub targets — scan local paths only. |
+| `-d`, `--reports-dir DIR` | Where to write reports (default: `reports/security`). Use a scratch dir to avoid touching committed reports. |
+| `-f`, `--fail` | Exit `1` if any scanned target is infected (for CI gating). |
+
+```bash
+saw scan                                  # scan the current repo
+saw scan ./service-a ./service-b          # scan specific paths
+saw scan -L -c config/security.yml        # local-only, configured targets
+saw scan -f                               # gate: non-zero exit on any finding
+```
+
+### `saw run`
+
+Run the full pipeline — **scan → report → alert** — in one process. Report paths are threaded
+internally, so you never pass intermediate JSON files by hand.
+
+```text
+saw run [PATHS...] [-L] [-c FILE] [-d DIR] [-f]
+```
+
+Accepts the same path/config/reports options as [`saw scan`](#saw-scan). Pass `-f` to gate the
+whole pipeline on findings.
+
+```bash
+saw run            # scan, render the report, send alerts — one command
+saw run -f         # same, but exit non-zero if anything was found
+```
+
+### `saw report`
+
+Render the latest scan results into a human-readable / markdown report.
+
+```text
+saw report [-l FILE]
+```
+
+| Option | Description |
+| --- | --- |
+| `-l`, `--latest FILE` | Latest results JSON to render (default: `reports/security/latest.json`). |
+
+### `saw alert`
+
+Emit alerts (Slack and/or GitHub issues) for the latest scan results.
+
+```text
+saw alert [-l FILE]
+```
+
+| Option | Description |
+| --- | --- |
+| `-l`, `--latest FILE` | Latest results JSON to alert on (default: `reports/security/latest.json`). |
+
+Reads credentials from the environment: `SLACK_WEBHOOK_URL`, `GITHUB_TOKEN`, `GITHUB_REPOSITORY`.
+
+### `saw fix`
+
+Remediate detected worm findings. **Dry-run by default** — it shows what would change unless you
+pass `--apply`.
+
+```text
+saw fix [--apply] [--pr] [--remote] [-c FILE]
+```
+
+| Option | Description |
+| --- | --- |
+| *(no flags)* | Dry-run: report the fixes that would be applied. |
+| `--apply` | Write fixes locally (originals backed up) and commit them to a branch. |
+| `--pr` | With `--apply`: push a stable `security/auto-clean` branch and open/update one rolling, de-duplicated PR per repo. |
+| `--remote` | Sweep the configured GitHub targets and open/update a dedup'd fix PR per repo. Needs a GitHub credential with repo + PR write scope (an env token or a `gh auth login` session). |
+| `-c`, `--config FILE` | Config file (default: `config/security.yml`). |
+
+```bash
+saw fix                       # dry-run — preview changes
+saw fix --apply               # apply fixes locally and commit to a branch
+saw fix --apply --pr          # apply + open/update one rolling PR per repo
+saw fix --remote              # open fix PRs across configured GitHub targets
+```
+
+### `saw audit`
+
+Run a local security hygiene audit: credential exposure, editor (VS Code) settings, and —
+optionally — a repository's default-branch protection.
+
+```text
+saw audit [--repo OWNER/NAME] [-b BRANCH] [-f]
+```
+
+| Option | Description |
+| --- | --- |
+| `--repo OWNER/NAME` | Also audit this repository's branch protection (needs a token). |
+| `-b`, `--branch NAME` | Branch to check protection for (default: `main`). |
+| `-f`, `--fail` | Exit `1` if any warning-level issue is found. |
+
+```bash
+saw audit                                       # local credential + editor hygiene
+saw audit --repo Ndevu12/strix -f               # also gate on branch-protection issues
+```
+
+### `saw search`
+
+Fuzzy "what's the command for…?" lookup over the whole command tree.
+
+```text
+saw search <text>
+```
+
+```bash
+saw search "open a pr"     # → suggests `saw fix --apply --pr`
+```
+
+### `saw doctor`
+
+Self-check: confirm that `saw` resolves to this installation, report whether a usable GitHub /
+Slack credential is present, and note that the health entry points (`stayawake-health-*`) are
+installed even though they are not `saw` subcommands.
+
+```text
+saw doctor
+```
+
+### `saw completion`
+
+Print a shell-completion script for your shell. See [Shell completion](#shell-completion).
+
+```text
+saw completion {bash,zsh,fish}
+```
+
+## Exit codes
+
+`saw` is quiet-friendly and scriptable — the exit code is the contract:
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Success / clean. (Also returned when findings exist but `-f/--fail` was not passed.) |
+| `1` | The gate tripped: actionable findings or issues were present **and** `-f/--fail` was set. |
+| `2` | Usage error (unknown command, bad option). |
+
+## Shell completion
+
+Because the short verbs are easiest to use with `<Tab>`, install completion once:
+
+```bash
+# bash
+saw completion bash > /etc/bash_completion.d/saw       # or source it from your ~/.bashrc
+
+# zsh
+saw completion zsh  > "${fpath[1]}/_saw"
+
+# fish
+saw completion fish > ~/.config/fish/completions/saw.fish
+```
+
+Verbs that share a first letter resolve at two characters: `re`→report, `ru`→run, `al`→alert,
+`au`→audit, `se`→search; `scan`→`s`, `doctor`→`d`, `fix`→`fix`.
+
+## Migrating from the legacy scripts
+
+Every legacy `stayawake-security-*` command has a shorter `saw` equivalent. **The legacy scripts
+keep working** (see [Compatibility & support](#compatibility--support)); migrate at your own pace.
+
+| Legacy command | `saw` equivalent |
+| --- | --- |
+| `stayawake-security-scan` | `saw scan` |
+| `stayawake-security-scan --fail-on-findings` | `saw scan -f` |
+| `stayawake-security-scan --local-only --config config/security.yml` | `saw scan -L -c config/security.yml` |
+| `stayawake-security-report` | `saw report` |
+| `stayawake-security-alert` | `saw alert` |
+| `stayawake-security-remediate` | `saw fix` |
+| `stayawake-security-remediate --apply --open-pr` | `saw fix --apply --pr` |
+| `stayawake-security-remediate --remote` | `saw fix --remote` |
+| `stayawake-security-audit --repo OWNER/NAME --fail-on-issues` | `saw audit --repo OWNER/NAME -f` |
+
+The renamed flags — `--local-only`→`--local`/`-L`, `--open-pr`→`--pr`, and the three
+`--fail-on-*` flags → `-f/--fail` — are also accepted under their old spellings as hidden
+aliases, so copy-pasted commands and existing scripts never break.
+
+## Compatibility & support
+
+- **Legacy scripts are frozen.** All eight `stayawake-*` console scripts (5 security, 3 health)
+  remain installed and accept their existing flags byte-for-byte. `saw` is **additive**; it never
+  removes or changes a legacy entry point.
+- **CI and Docker are unaffected.** The remote workflows
+  ([security-sentinel.yml](../.github/workflows/security-sentinel.yml),
+  [security-remediate.yml](../.github/workflows/security-remediate.yml),
+  [worm-guard.yml](../.github/workflows/worm-guard.yml)) and the Docker image call the legacy
+  scripts and continue to work unchanged. The flags `--local-only` and `--fail-on-findings` are a
+  **frozen public contract** relied on by the SHA-pinned `worm-guard` scanner.
+- **Health stays remote-only.** The `stayawake-health-*` scripts powering the `*/5` uptime cron
+  ([stayawake-sentinel.yml](../.github/workflows/stayawake-sentinel.yml)) are untouched and are
+  intentionally not exposed as `saw` subcommands.
+- **Deprecation.** A future major release may remove the legacy *security* scripts and old flag
+  spellings; they will warn (to stderr, suppressible via `STAYAWAKE_NO_DEPRECATION=1`) before
+  removal. `pip install stayawakebot` remains stable throughout.
+
+## Appendix: design rationale
+
+> Background on why the CLI is shaped this way. Not needed to use `saw`.
+
+### Why `saw`, and why security-only
+
+The CLI replaces eight long hyphenated scripts (`stayawake-security-scan`, …) whose names were
+hard to discover and remember, and whose "fail" flag was spelled three different ways. Because
+only the security bot runs locally, the CLI is **security-only** and uses **flat top-level verbs**
+(no bot-noun) for `git`/`cargo`-style terseness. The name `saw` is three keystrokes, a security
+pun ("the sentinel *saw* the worm"), and the acronym of **St‑A‑W**ake; a `stayawake` long alias
+ships alongside it as a collision-proof fallback.
+
+### Keystroke comparison
+
+| Operation | Legacy | `saw` | Reduction |
+| --- | --- | --- | --- |
+| Scan + CI gate | `stayawake-security-scan --fail-on-findings` | `saw scan -f` | −74% |
+| Full pipeline | `…scan && …report && …alert` | `saw run` | −91% |
+| Remediate + PR | `stayawake-security-remediate --apply --open-pr` | `saw fix --apply --pr` | −57% |
+| Audit + gate | `stayawake-security-audit --repo … --fail-on-issues` | `saw audit --repo … -f` | −46% |
+
+### Design decisions
+
+| Decision | Choice |
+| --- | --- |
+| Scope | Security-only CLI; health stays remote-only, scripts unchanged |
+| Binary | `saw` (+ `stayawake` collision-proof long alias) |
+| Command shape | Flat top-level verbs; hidden reserved `saw sec <verb>` seam for a future 2nd local bot |
+| Fail flag | Single `-f`/`--fail`; legacy `--fail-on-*` kept as hidden aliases |
+| Pipeline | `run` (no scope arg — one bot) |
+| `remediate` → `fix`; `find` → `search` | Terser verbs; `search` avoids the `fix` prefix clash |
+| `alias` | Full-word only, so `al` resolves to `alert` |
+| Back-compat | All 8 `stayawake-*` scripts frozen byte-for-byte; new flag spellings additive |
+
+### Reserved for the future
+
+The visible surface is flat, but `saw sec <verb>` is reserved (hidden) as a namespace seam. If a
+second capability ever needs a local CLI, the convention is already set — each bot owns a
+`saw <bot> …` group, with the primary bot's verbs promoted to the root as shortcuts — so a future
+`saw health …` would be symmetric with the reserved `saw sec …`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,10 @@ Repository = "https://github.com/Ndevu12/stayAwakeBot"
 
 # Console scripts (available after `pip install`); each maps to an existing thin main() (DRY).
 [project.scripts]
+# Unified terse CLI (security-only) + a collision-proof long alias. See docs/CLI.md.
+saw                        = "stayawake.cli:main"
+stayawake                  = "stayawake.cli:main"
+# Legacy per-bot scripts — FROZEN: remote workflows + Docker depend on these byte-for-byte.
 stayawake-health-check     = "stayawake.bots.health.cli.check:main"
 stayawake-health-report    = "stayawake.bots.health.cli.report:main"
 stayawake-health-alert     = "stayawake.bots.health.cli.alert:main"

--- a/src/stayawake/cli/__init__.py
+++ b/src/stayawake/cli/__init__.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""`saw` — StayAwakeBot's terse, security-only command-line interface.
+
+A thin ROUTING layer: the dispatcher ([dispatch.py]) wires together one module per
+command ([commands/]) and forwards each verb to the SAME security `service.*` /
+`remediator` / `hygiene` functions the legacy `stayawake-security-*` console scripts
+already call — no detection or remediation logic lives here. The legacy scripts stay
+installed and unchanged; `saw` is purely additive. See docs/CLI.md for the user guide.
+
+The `saw` and `stayawake` console scripts both resolve to `main` below.
+"""
+from __future__ import annotations
+
+from stayawake.cli._meta import DEFAULT_LATEST, DEFAULT_REPORTS, VERBS, __version__
+from stayawake.cli.dispatch import build_parser, main
+
+__all__ = ["main", "build_parser", "VERBS", "DEFAULT_LATEST", "DEFAULT_REPORTS", "__version__"]

--- a/src/stayawake/cli/_meta.py
+++ b/src/stayawake/cli/_meta.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""Shared constants for the `saw` CLI.
+
+A dependency-light leaf module (it imports nothing from the `stayawake.cli` package)
+so command modules and the dispatcher can import it freely without import cycles.
+"""
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError, version as _pkg_version
+
+try:                                       # version is derived from the git tag at build time
+    __version__ = _pkg_version("stayawakebot")
+except PackageNotFoundError:               # running from a source tree without an installed dist
+    __version__ = "0+unknown"
+
+DEFAULT_REPORTS = "reports/security"
+DEFAULT_LATEST = "reports/security/latest.json"
+
+# Canonical verbs in display order — used by `completion` and the conflict-guard test.
+VERBS = ["scan", "run", "report", "alert", "fix", "audit", "search", "doctor", "completion"]

--- a/src/stayawake/cli/commands/__init__.py
+++ b/src/stayawake/cli/commands/__init__.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+"""Command registry for the `saw` CLI.
+
+Each command lives in its own module and exposes `register(subparsers)`, which adds
+its parser and binds its handler via `set_defaults(func=...)`. Adding a command is a
+new module here plus one entry in `REGISTRARS` — nothing in the dispatcher changes.
+The list order controls help-display order.
+"""
+from __future__ import annotations
+
+from . import alert, audit, completion, doctor, fix, report, run, scan, search
+
+REGISTRARS = [scan, run, report, alert, fix, audit, search, doctor, completion]

--- a/src/stayawake/cli/commands/alert.py
+++ b/src/stayawake/cli/commands/alert.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""`saw alert` — emit Slack / GitHub alerts for the latest scan. Routes to alerter.run."""
+from __future__ import annotations
+
+import argparse
+
+from stayawake.bots.security import alerter
+from stayawake.cli._meta import DEFAULT_LATEST
+
+
+def register(sub) -> None:
+    p = sub.add_parser("alert", aliases=["al"], help="emit security alerts")
+    p.add_argument("-l", "--latest", default=DEFAULT_LATEST,
+                   help=f"results JSON to alert on (default: {DEFAULT_LATEST})")
+    p.set_defaults(func=run)
+
+
+def run(a: argparse.Namespace) -> int:
+    alerter.run(latest_path=a.latest)
+    return 0

--- a/src/stayawake/cli/commands/audit.py
+++ b/src/stayawake/cli/commands/audit.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""`saw audit` — credential + editor + branch-protection hygiene audit."""
+from __future__ import annotations
+
+import argparse
+
+from stayawake.bots.security import hygiene
+from stayawake.core import auth
+
+
+def register(sub) -> None:
+    p = sub.add_parser("audit", aliases=["au"], help="hygiene + branch-protection audit")
+    p.add_argument("--repo", metavar="OWNER/NAME", default=None,
+                   help="also audit this repo's branch protection (needs a token)")
+    p.add_argument("-b", "--branch", default="main",
+                   help="branch to check protection for (default: main)")
+    p.add_argument("-f", "--fail", "--fail-on-issues", action="store_true", dest="fail",
+                   help="exit non-zero if any warning-level issue is found")
+    p.set_defaults(func=run)
+
+
+def run(a: argparse.Namespace) -> int:
+    token, _ = auth.resolve_token()
+    if a.repo and not token:
+        print(auth.no_credential_hint("auditing branch protection") +
+              " Skipping the branch-protection check.\n")
+    issues = (hygiene.check_credentials() + hygiene.check_vscode()
+              + hygiene.check_branch_protection(a.repo, token, a.branch))
+    print(hygiene.render(issues))
+    warnings = [i for i in issues if i.severity == "warning"]
+    return 1 if (a.fail and warnings) else 0

--- a/src/stayawake/cli/commands/completion.py
+++ b/src/stayawake/cli/commands/completion.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""`saw completion {bash,zsh,fish}` — emit a shell-completion script for `saw`/`stayawake`."""
+from __future__ import annotations
+
+import argparse
+
+from stayawake.cli._meta import VERBS
+
+
+def register(sub) -> None:
+    p = sub.add_parser("completion", aliases=["comp"], help="emit a shell-completion script")
+    p.add_argument("shell", choices=["bash", "zsh", "fish"])
+    p.set_defaults(func=run)
+
+
+def run(a: argparse.Namespace) -> int:
+    verbs = " ".join(VERBS)
+    if a.shell == "bash":
+        print(
+            '# saw bash completion — `eval "$(saw completion bash)"` or save to a '
+            "completion dir\n"
+            "_saw_completion() {\n"
+            '  local cur="${COMP_WORDS[COMP_CWORD]}"\n'
+            '  if [ "$COMP_CWORD" -eq 1 ]; then\n'
+            f'    COMPREPLY=( $(compgen -W "{verbs}" -- "$cur") )\n'
+            "  fi\n"
+            "}\n"
+            "complete -F _saw_completion saw stayawake"
+        )
+    elif a.shell == "zsh":
+        print(
+            "#compdef saw stayawake\n"
+            "# saw zsh completion — save as _saw somewhere on your $fpath\n"
+            "_saw() {\n"
+            f"  local -a verbs; verbs=({verbs})\n"
+            "  _arguments '1: :->cmd' '*::arg:->args'\n"
+            "  [[ $state == cmd ]] && _describe 'command' verbs\n"
+            "}\n"
+            '_saw "$@"'
+        )
+    else:  # fish
+        for binary in ("saw", "stayawake"):
+            for v in VERBS:
+                print(f"complete -c {binary} -n '__fish_use_subcommand' -a {v}")
+    return 0

--- a/src/stayawake/cli/commands/doctor.py
+++ b/src/stayawake/cli/commands/doctor.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""`saw doctor` — self-check the install and credentials.
+
+A dispatcher-owned command, so it honours --json / -q. It also reports that the
+health entry points are installed even though they are not `saw` subcommands.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+
+from stayawake.cli._meta import __version__
+from stayawake.core import auth
+
+
+def register(sub) -> None:
+    p = sub.add_parser("doctor", aliases=["d", "doc"], help="self-check install + credentials")
+    p.add_argument("--json", action="store_true", help="machine-readable output")
+    p.add_argument("-q", "--quiet", action="store_true", help="print only problems")
+    p.set_defaults(func=run)
+
+
+def run(a: argparse.Namespace) -> int:
+    saw_path = shutil.which("saw") or shutil.which("stayawake")
+    _, source = auth.resolve_token()
+    health = shutil.which("stayawake-health-check")
+
+    if a.json:
+        print(json.dumps({
+            "saw_on_path": saw_path,
+            "credential": source,
+            "health_scripts_installed": bool(health),
+            "version": __version__,
+        }, indent=2))
+        return 0
+
+    def mark(ok: bool) -> str:
+        return "✓" if ok else "✗"
+
+    lines = [
+        f"{mark(bool(saw_path))} saw resolves to: {saw_path or 'NOT FOUND on PATH'}",
+        (f"✓ GitHub credential: {source}" if source else
+         "• no GitHub credential (public scans + local audit still work; needed "
+         "for private repos and remote fix PRs)"),
+        f"{mark(bool(health))} health entry points installed (remote-only, not saw "
+        f"subcommands): {'yes' if health else 'no'}",
+        f"• version: {__version__}",
+    ]
+    if a.quiet:
+        problems = [ln for ln in lines if ln.startswith("✗")]
+        print("\n".join(problems) if problems else "ok")
+    else:
+        print("\n".join(lines))
+    return 0

--- a/src/stayawake/cli/commands/fix.py
+++ b/src/stayawake/cli/commands/fix.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""`saw fix` — remediate findings (dry-run by default). Routes to remediator."""
+from __future__ import annotations
+
+import argparse
+
+from stayawake.bots.security import remediator
+
+
+def register(sub) -> None:
+    p = sub.add_parser("fix", help="remediate findings (dry-run by default)")
+    p.add_argument("-c", "--config", default="config/security.yml")
+    p.add_argument("--apply", action="store_true",
+                   help="apply local fixes (backed up) and commit to a branch")
+    p.add_argument("--pr", "--open-pr", action="store_true", dest="pr",
+                   help="with --apply: push a fix branch and open/update one PR per repo")
+    p.add_argument("--remote", action="store_true",
+                   help="sweep configured GitHub targets and open/update a fix PR per repo")
+    p.set_defaults(func=run)
+
+
+def run(a: argparse.Namespace) -> int:
+    if a.remote:
+        # submit_org_prs returns the COUNT of repos that got a PR, not an exit code —
+        # a successful sweep must still exit 0 (matches the legacy remediate script).
+        remediator.submit_org_prs(a.config)
+        return 0
+    remediator.remediate(a.config, apply=a.apply, open_pr=a.pr)
+    return 0

--- a/src/stayawake/cli/commands/report.py
+++ b/src/stayawake/cli/commands/report.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""`saw report` — render the latest scan into a report. Routes to reporter.generate."""
+from __future__ import annotations
+
+import argparse
+
+from stayawake.bots.security import reporter
+from stayawake.cli._meta import DEFAULT_LATEST
+
+
+def register(sub) -> None:
+    p = sub.add_parser("report", aliases=["rep", "re"], help="render latest security report")
+    p.add_argument("-l", "--latest", default=DEFAULT_LATEST,
+                   help=f"results JSON to render (default: {DEFAULT_LATEST})")
+    p.set_defaults(func=run)
+
+
+def run(a: argparse.Namespace) -> int:
+    reporter.generate(latest_path=a.latest)
+    return 0

--- a/src/stayawake/cli/commands/run.py
+++ b/src/stayawake/cli/commands/run.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""`saw run` — the scan -> report -> alert pipeline in one pass.
+
+Reuses `scan`'s arguments and threads the report path internally, so the user never
+names the intermediate latest.json. The reports dir is resolved ONCE (honouring -d,
+then STAYAWAKE_REPORTS_DIR, then the default) and reused for the scan and for the
+report/alert reads, so the three stages always agree on where latest.json lives.
+"""
+from __future__ import annotations
+
+import argparse
+
+from stayawake.bots.security import alerter, reporter, service
+from stayawake.bots.security.service import REPORTS_DIR
+from stayawake.cli.commands.scan import add_scan_args
+from stayawake.core.io import resolve_reports_dir
+
+
+def register(sub) -> None:
+    p = sub.add_parser("run", aliases=["ru"], help="scan -> report -> alert pipeline")
+    add_scan_args(p)
+    p.add_argument("-f", "--fail", "--fail-on-findings", action="store_true", dest="fail",
+                   help="exit non-zero if any target is infected")
+    p.set_defaults(func=run)
+
+
+def run(a: argparse.Namespace) -> int:
+    reports_dir = resolve_reports_dir(a.reports_dir, default=REPORTS_DIR)
+    paths = [*a.paths, *a.extra_paths]
+    code = service.scan(a.config, a.local, a.fail, reports_dir, paths or None)
+    latest = str(reports_dir / "latest.json")
+    reporter.generate(latest_path=latest)
+    alerter.run(latest_path=latest)
+    return code

--- a/src/stayawake/cli/commands/scan.py
+++ b/src/stayawake/cli/commands/scan.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""`saw scan` — hunt supply-chain worms. Routes to security.service.scan."""
+from __future__ import annotations
+
+import argparse
+
+from stayawake.bots.security import service
+
+
+def add_scan_args(p: argparse.ArgumentParser) -> None:
+    """The path/config/reports options shared by `scan` and the `run` pipeline."""
+    p.add_argument("paths", nargs="*", metavar="PATHS",
+                   help="repo/dir paths to scan (local). Omit to scan the current repo.")
+    p.add_argument("-p", "--path", action="append", default=[], dest="extra_paths",
+                   metavar="PATH", help="additional path to scan (repeatable)")
+    p.add_argument("-c", "--config", default=None,
+                   help="config file (default: config/security.yml when present)")
+    p.add_argument("-L", "--local", "--local-only", action="store_true", dest="local",
+                   help="skip remote GitHub targets — scan local paths only")
+    p.add_argument("-d", "--reports-dir", default=None, dest="reports_dir",
+                   help="where to write reports (default: reports/security)")
+
+
+def register(sub) -> None:
+    p = sub.add_parser("scan", aliases=["s", "sc"], help="hunt supply-chain worms")
+    add_scan_args(p)
+    p.add_argument("-f", "--fail", "--fail-on-findings", action="store_true", dest="fail",
+                   help="exit non-zero if any target is infected (CI gate)")
+    p.set_defaults(func=run)
+
+
+def run(a: argparse.Namespace) -> int:
+    paths = [*a.paths, *a.extra_paths]
+    return service.scan(a.config, a.local, a.fail, a.reports_dir, paths or None)

--- a/src/stayawake/cli/commands/search.py
+++ b/src/stayawake/cli/commands/search.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""`saw search` — fuzzy "what's the command for…?" lookup over the command tree.
+
+A dispatcher-owned command (it produces its own output), so it honours --json / -q.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+
+# (command, summary, extra search keywords)
+_INDEX = [
+    ("saw scan", "hunt supply-chain worms in repos/dirs",
+     "scan check find worm malware detect virus infect supply chain"),
+    ("saw run", "scan, then report, then alert in one pass",
+     "run pipeline all everything chain"),
+    ("saw report", "render the latest scan into a report",
+     "report render status markdown output html"),
+    ("saw alert", "send Slack / GitHub alerts for the latest scan",
+     "alert notify slack issue warn ping"),
+    ("saw fix", "remediate findings (dry-run unless --apply); --pr opens a PR",
+     "fix remediate clean repair remove pr pull request open"),
+    ("saw audit", "credential + editor + branch-protection hygiene audit",
+     "audit hygiene credential token branch protection vscode editor"),
+    ("saw doctor", "self-check the install and credentials",
+     "doctor diagnose verify install check health"),
+    ("saw completion", "emit a shell-completion script",
+     "completion shell bash zsh fish autocomplete tab"),
+]
+
+
+def register(sub) -> None:
+    p = sub.add_parser("search", aliases=["se"], help="fuzzy 'what's the command for…?'")
+    p.add_argument("text", nargs="+", metavar="TEXT")
+    p.add_argument("--json", action="store_true", help="machine-readable output")
+    p.add_argument("-q", "--quiet", action="store_true", help="print only command names")
+    p.set_defaults(func=run)
+
+
+def run(a: argparse.Namespace) -> int:
+    terms = " ".join(a.text).lower().split()
+    scored = []
+    for cmd, summary, keywords in _INDEX:
+        hay = f"{cmd} {summary} {keywords}".lower()
+        score = sum(1 for t in terms if t in hay)
+        if score:
+            scored.append((score, cmd, summary))
+    scored.sort(key=lambda x: (-x[0], x[1]))
+
+    if a.json:
+        print(json.dumps([{"command": c, "summary": s} for _, c, s in scored], indent=2))
+        return 0
+    if not scored:
+        # No match is a normal empty result, not a gate failure — keep exit 0 so it
+        # never looks like the `1` the security commands return when --fail trips.
+        print(f"No commands match {' '.join(a.text)!r}. Try `saw -h` for the full list.")
+        return 0
+    for _, cmd, summary in scored:
+        print(cmd if a.quiet else f"{cmd:<16}{summary}")
+    return 0

--- a/src/stayawake/cli/dispatch.py
+++ b/src/stayawake/cli/dispatch.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Builds the root `saw` parser and dispatches to command handlers.
+
+This is the only place that knows about the whole tree; it stays thin by delegating
+each verb to a module in `stayawake.cli.commands`.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+
+from stayawake.cli import commands
+from stayawake.cli._meta import __version__
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="saw",
+        description="StayAwakeBot sentinel toolkit — local supply-chain worm hunter.",
+        epilog="Run `saw <command> -h` for command-specific help.",
+    )
+    p.add_argument(
+        "--version", action="version",
+        version=(f"saw (stayawakebot) {__version__}\n"
+                 "capabilities: security: local + CI; health: CI-only (stayawake-health-*)"),
+    )
+    sub = p.add_subparsers(dest="command", metavar="<command>")
+    for module in commands.REGISTRARS:
+        module.register(sub)
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = list(sys.argv[1:] if argv is None else argv)
+    # Hidden, reserved `saw sec <verb>` namespace: a leading `sec` token is a no-op
+    # synonym today (every verb is already at the root) and a seam for a future bot.
+    if argv and argv[0] == "sec":
+        argv = argv[1:]
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if not getattr(args, "command", None):
+        parser.print_help()
+        return 0
+    return args.func(args)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Tests for the unified `saw` dispatcher (stayawake.cli).
+
+These verify pure ROUTING — that each verb maps to the right service call with the
+right arguments — plus the back-compat guards the redesign promised:
+  * no subcommand/alias name collisions (so a future verb can't silently shadow one),
+  * legacy flag spellings (--fail-on-findings / --local-only / --open-pr) still parse,
+  * the `saw sec <verb>` namespace seam is a transparent no-op today,
+  * pyproject keeps all 8 legacy console scripts AND adds saw/stayawake.
+The real scanning/remediation functions are mocked; we assert how they are called.
+"""
+from __future__ import annotations
+
+import argparse
+import io
+import pathlib
+import tomllib
+import unittest
+from contextlib import redirect_stdout
+from unittest import mock
+
+from stayawake import cli
+
+
+class TestParserIntegrity(unittest.TestCase):
+    def _subaction(self):
+        parser = cli.build_parser()
+        for action in parser._actions:
+            if isinstance(action, argparse._SubParsersAction):
+                return action
+        raise AssertionError("no subparsers action found")
+
+    def test_no_name_or_alias_collisions(self):
+        names = list(self._subaction()._name_parser_map.keys())
+        self.assertEqual(len(names), len(set(names)), f"duplicate names: {names}")
+
+    def test_all_canonical_verbs_present(self):
+        names = self._subaction()._name_parser_map.keys()
+        for verb in cli.VERBS:
+            self.assertIn(verb, names)
+
+
+class TestScanRouting(unittest.TestCase):
+    @mock.patch("stayawake.bots.security.service.scan", return_value=0)
+    def test_flags_map_to_service_signature(self, m):
+        rc = cli.main(["scan", "-f", "-L", "-c", "cfg.yml", "./repo", "-p", "extra"])
+        self.assertEqual(rc, 0)
+        config_path, local_only, fail_on_findings, reports_dir, paths = m.call_args.args
+        self.assertEqual(config_path, "cfg.yml")
+        self.assertTrue(local_only)
+        self.assertTrue(fail_on_findings)
+        self.assertIsNone(reports_dir)
+        self.assertIn("./repo", paths)
+        self.assertIn("extra", paths)
+
+    @mock.patch("stayawake.bots.security.service.scan", return_value=1)
+    def test_legacy_flag_aliases_still_parse(self, m):
+        rc = cli.main(["scan", "--fail-on-findings", "--local-only"])
+        self.assertEqual(rc, 1)
+        _, local_only, fail_on_findings, _, _ = m.call_args.args
+        self.assertTrue(local_only)
+        self.assertTrue(fail_on_findings)
+
+    @mock.patch("stayawake.bots.security.service.scan", return_value=0)
+    def test_bare_scan_passes_no_paths(self, m):
+        cli.main(["scan"])
+        self.assertIsNone(m.call_args.args[4])
+
+    @mock.patch("stayawake.bots.security.service.scan", return_value=0)
+    def test_short_alias_routes_to_scan(self, m):
+        cli.main(["s", "-f"])
+        self.assertTrue(m.call_args.args[2])
+
+
+class TestSecNamespace(unittest.TestCase):
+    @mock.patch("stayawake.bots.security.service.scan", return_value=0)
+    def test_leading_sec_token_is_stripped(self, m):
+        cli.main(["sec", "scan", "-f"])
+        self.assertTrue(m.call_args.args[2])
+
+
+class TestRunPipeline(unittest.TestCase):
+    @mock.patch("stayawake.cli.commands.run.resolve_reports_dir",
+                return_value=pathlib.Path("/tmp/r"))
+    @mock.patch("stayawake.bots.security.alerter.run")
+    @mock.patch("stayawake.bots.security.reporter.generate")
+    @mock.patch("stayawake.bots.security.service.scan", return_value=1)
+    def test_run_threads_one_reports_dir_and_returns_scan_exit(
+            self, m_scan, m_report, m_alert, _resolve):
+        rc = cli.main(["run", "-f", "-d", "/tmp/r"])
+        self.assertEqual(rc, 1)
+        # The pipeline must resolve the reports dir ONCE and feed the same value to
+        # the scan (positional 4) and to report/alert, so all three stages agree.
+        self.assertEqual(m_scan.call_args.args[3], pathlib.Path("/tmp/r"))
+        self.assertEqual(m_report.call_args.kwargs["latest_path"], "/tmp/r/latest.json")
+        self.assertEqual(m_alert.call_args.kwargs["latest_path"], "/tmp/r/latest.json")
+
+
+class TestReportAlert(unittest.TestCase):
+    @mock.patch("stayawake.bots.security.reporter.generate")
+    def test_report_uses_latest_flag(self, m):
+        cli.main(["report", "-l", "x.json"])
+        self.assertEqual(m.call_args.kwargs["latest_path"], "x.json")
+
+    @mock.patch("stayawake.bots.security.alerter.run")
+    def test_alert_default_latest(self, m):
+        cli.main(["alert"])
+        self.assertEqual(m.call_args.kwargs["latest_path"], cli.DEFAULT_LATEST)
+
+
+class TestFix(unittest.TestCase):
+    @mock.patch("stayawake.bots.security.remediator.remediate")
+    def test_local_apply_pr(self, m):
+        rc = cli.main(["fix", "--apply", "--pr"])
+        self.assertEqual(rc, 0)
+        self.assertEqual(m.call_args.kwargs, {"apply": True, "open_pr": True})
+
+    @mock.patch("stayawake.bots.security.remediator.remediate")
+    def test_open_pr_legacy_alias(self, m):
+        cli.main(["fix", "--apply", "--open-pr"])
+        self.assertTrue(m.call_args.kwargs["open_pr"])
+
+    @mock.patch("stayawake.bots.security.remediator.submit_org_prs", return_value=0)
+    def test_remote_routes_to_org_prs(self, m):
+        rc = cli.main(["fix", "--remote"])
+        self.assertEqual(rc, 0)
+        m.assert_called_once()
+
+    @mock.patch("stayawake.bots.security.remediator.submit_org_prs", return_value=3)
+    def test_remote_exit_zero_even_when_prs_opened(self, _):
+        # submit_org_prs returns a COUNT of repos, not an exit code; a successful
+        # sweep that opens 3 PRs must still exit 0, not 3.
+        self.assertEqual(cli.main(["fix", "--remote"]), 0)
+
+
+class TestAudit(unittest.TestCase):
+    @mock.patch("stayawake.bots.security.hygiene.render", return_value="")
+    @mock.patch("stayawake.bots.security.hygiene.check_branch_protection", return_value=[])
+    @mock.patch("stayawake.bots.security.hygiene.check_vscode", return_value=[])
+    @mock.patch("stayawake.bots.security.hygiene.check_credentials", return_value=[])
+    @mock.patch("stayawake.core.auth.resolve_token", return_value=(None, None))
+    def test_clean_audit_returns_zero(self, *_):
+        with redirect_stdout(io.StringIO()):
+            self.assertEqual(cli.main(["audit"]), 0)
+
+    @mock.patch("stayawake.bots.security.hygiene.render", return_value="")
+    @mock.patch("stayawake.bots.security.hygiene.check_branch_protection", return_value=[])
+    @mock.patch("stayawake.bots.security.hygiene.check_vscode", return_value=[])
+    @mock.patch("stayawake.bots.security.hygiene.check_credentials")
+    @mock.patch("stayawake.core.auth.resolve_token", return_value=(None, None))
+    def test_fail_flag_gates_on_warning(self, _tok, m_cred, *_):
+        warning = mock.Mock()
+        warning.severity = "warning"
+        m_cred.return_value = [warning]
+        with redirect_stdout(io.StringIO()):
+            self.assertEqual(cli.main(["audit", "-f"]), 1)
+
+
+class TestDispatcherOwnedCommands(unittest.TestCase):
+    @mock.patch("stayawake.core.auth.resolve_token", return_value=(None, None))
+    def test_doctor_runs(self, _):
+        with redirect_stdout(io.StringIO()) as buf:
+            self.assertEqual(cli.main(["doctor"]), 0)
+        self.assertIn("saw resolves to", buf.getvalue())
+
+    def test_search_finds_remediation(self):
+        with redirect_stdout(io.StringIO()) as buf:
+            self.assertEqual(cli.main(["search", "open", "a", "pr"]), 0)
+        self.assertIn("saw fix", buf.getvalue())
+
+    def test_search_no_match_returns_zero(self):
+        with redirect_stdout(io.StringIO()):
+            self.assertEqual(cli.main(["search", "zzzznotacommand"]), 0)
+
+    def test_completion_bash(self):
+        with redirect_stdout(io.StringIO()) as buf:
+            self.assertEqual(cli.main(["completion", "bash"]), 0)
+        self.assertIn("complete -F", buf.getvalue())
+
+
+class TestTopLevel(unittest.TestCase):
+    def test_no_command_prints_help(self):
+        with redirect_stdout(io.StringIO()) as buf:
+            self.assertEqual(cli.main([]), 0)
+        self.assertIn("usage", buf.getvalue().lower())
+
+    def test_version_exits_zero(self):
+        with self.assertRaises(SystemExit) as cm, redirect_stdout(io.StringIO()):
+            cli.main(["--version"])
+        self.assertEqual(cm.exception.code, 0)
+
+
+class TestPyprojectScripts(unittest.TestCase):
+    def test_entry_points(self):
+        data = tomllib.loads(pathlib.Path("pyproject.toml").read_text(encoding="utf-8"))
+        scripts = data["project"]["scripts"]
+        for legacy in ("stayawake-health-check", "stayawake-health-report",
+                       "stayawake-health-alert", "stayawake-security-scan",
+                       "stayawake-security-report", "stayawake-security-alert",
+                       "stayawake-security-remediate", "stayawake-security-audit"):
+            self.assertIn(legacy, scripts, f"legacy script {legacy} must stay registered")
+        self.assertEqual(scripts.get("saw"), "stayawake.cli:main")
+        self.assertEqual(scripts.get("stayawake"), "stayawake.cli:main")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Adds a single **`saw`** (and a collision-proof **`stayawake`**) console command that replaces the long `stayawake-security-*` scripts with terse, discoverable, `gh`/`az`-style commands.

```
saw scan [PATHS]    hunt supply-chain worms      (-f/--fail  -L/--local  -c  -p  -d)
saw run             scan -> report -> alert pipeline
saw report | alert  render / send the latest scan
saw fix             remediate (--apply  --pr  --remote)
saw audit           hygiene + branch-protection audit
saw search | doctor | completion {bash,zsh,fish}
```

`saw scan -f` replaces `stayawake-security-scan --fail-on-findings` (-74% keystrokes); `saw run` replaces the three-command pipeline.

## Design

- **Security-only by design.** The health (uptime) bot runs remotely-only and is intentionally not exposed; its `stayawake-health-*` scripts are untouched.
- **Pure routing.** No detection/remediation logic moves — each verb forwards to the same `bots/security` service functions the legacy scripts call.
- **One module per verb** under `src/stayawake/cli/commands/`, registered via a small registry (mirrors the repo's per-command layout). Adding a command = one new file + one list entry.
- **Unified `-f/--fail`** replaces `--fail-on-findings` / `--fail-on-issues` (kept as hidden aliases). Renamed `remediate`->`fix`, `find`->`search`.
- **Zero breakage.** All 8 legacy `stayawake-*` console scripts stay registered byte-for-byte; CI workflows, the `strix` Action, and Docker are unaffected.

## Tests

- New `tests/test_cli.py` (23 cases): routing per verb, legacy flag aliases, the no-collision guard, the reserved `sec` seam, the frozen `[project.scripts]`, and the two bug-fix regressions below.
- Full suite: **128 passing** (`python -m unittest discover -s tests`).

## Fixes from self-review (`/code-review high`)

- `saw run` resolves the reports dir once (honoring `-d` + `STAYAWAKE_REPORTS_DIR`) so scan and report/alert always agree on `latest.json` — previously the pipeline read a stale/missing file in the container.
- `saw fix --remote` exits `0` on success (`submit_org_prs` returns a repo *count*, not an exit code — previously leaked as a nonzero exit).
- `saw search` no-match returns `0` (was `1`, which collides with the `--fail` gate contract).

## Status

Implemented and working from source. See **[docs/CLI.md](docs/CLI.md)** for the full command guide. The CLI is not in a tagged PyPI release yet.