### PR TITLE
docs: switch CLI examples to the `saw` security commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,11 +69,11 @@ ENV STAYAWAKE_REPORTS_DIR=/tmp/stayawake
 
 # Mount the repository to scan at /repo (read-only is fine for scanning), e.g.:
 #   docker run --rm -v "$PWD:/repo:ro" ghcr.io/ndevu12/stayawakebot \
-#     stayawake-security-scan --local-only --fail-on-findings
+#     saw scan --local --fail
 # To keep the report on the host, mount a writable dir and run as your own uid so the
 # bind-mount is writable:
 #   docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/repo" \
-#     ghcr.io/ndevu12/stayawakebot stayawake-security-scan --local-only --reports-dir /repo/reports
-# The package ships several console scripts, so there is no single ENTRYPOINT — name the
-# command you want. A bare `docker run` prints the security scanner's help.
-CMD ["stayawake-security-scan", "--help"]
+#     ghcr.io/ndevu12/stayawakebot saw scan --local --reports-dir /repo/reports
+# The package ships several console scripts (saw, plus the legacy stayawake-*), so there is no
+# single ENTRYPOINT — name the command you want. A bare `docker run` prints the saw CLI help.
+CMD ["saw", "--help"]

--- a/README.md
+++ b/README.md
@@ -24,12 +24,13 @@ commit reports back to the repository — the same packaged code in both places.
 pip install stayawakebot                                            # from PyPI (released versions)
 # or the latest from source:
 pip install "stayawakebot @ git+https://github.com/Ndevu12/stayAwakeBot@main"
-stayawake-health-check  --config config/urls.yml                    # uptime check
-stayawake-security-scan --config config/security.yml --local-only   # worm scan
+stayawake-health-check  --config config/urls.yml                    # uptime check (remote-only bot)
+saw scan --config config/security.yml --local                       # worm scan (local security CLI)
 ```
 
-> The distribution is published as **`stayawakebot`** (the name `stayawake` is taken on
-> PyPI by an unrelated project); the import package and `stayawake-*` commands are unchanged.
+> The distribution is published as **`stayawakebot`** (the name `stayawake` is taken on PyPI by
+> an unrelated project). Local security runs through the terse **`saw`** command (see the
+> [CLI guide](docs/CLI.md)); the legacy `stayawake-*` console scripts are unchanged and still work.
 
 ## Gate any repo's CI (GitHub Action)
 
@@ -59,7 +60,7 @@ Prefer not to install a Python toolchain at all? Pull the image and scan a mount
 
 ```bash
 docker run --rm -v "$PWD:/repo:ro" ghcr.io/ndevu12/stayawakebot \
-  stayawake-security-scan --local-only --fail-on-findings
+  saw scan --local --fail
 ```
 
 The exit code is the verdict (`0` clean, `1` findings). To keep the report file too, mount a
@@ -68,7 +69,7 @@ writable dir and run as your own user so the bind-mount is writable:
 ```bash
 docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/repo" \
   ghcr.io/ndevu12/stayawakebot \
-  stayawake-security-scan --local-only --reports-dir /repo/reports
+  saw scan --local --reports-dir /repo/reports
 ```
 
 Tags: `:latest`, `:X.Y.Z`, `:X.Y`, and `:sha-<commit>`. The image runs as a non-root user, is
@@ -76,6 +77,7 @@ built from the same wheel published to PyPI, and ships SLSA provenance + SBOM at
 
 ## Documentation
 
+- [CLI command guide](docs/CLI.md) — the `saw` security commands (scan, run, fix, audit, …)
 - [Usage](docs/USAGE.md) — install, run both bots, secrets, GitHub Actions, deploy your own
 - [Configuration & Reports](docs/CONFIGURATION.md) — config file fields and report formats
 - [Architecture](docs/ARCHITECTURE.md) — package layout and design principles

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -33,11 +33,11 @@ docs/  prevent/  reports/  .github/  CONTRIBUTING.md
 ## Install & run
 ```bash
 pip install -e .            # or: pip install .
-stayawake-health-check   --config config/urls.yml
+stayawake-health-check   --config config/urls.yml    # health bot is remote-only; scripts kept for CI
 stayawake-health-report
 stayawake-health-alert
-stayawake-security-scan  --config config/security.yml
-stayawake-security-remediate [--apply] [--open-pr] [--remote]
+saw scan  --config config/security.yml               # local security CLI (see docs/CLI.md)
+saw fix [--apply] [--pr] [--remote]
 python -m unittest discover -s tests      # tests (package must be installed)
 ```
 (`python -m stayawake.bots.<bot>.cli.<action>` works too.)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -55,8 +55,8 @@ at a custom DB with `settings.signatures_path`. Full field reference and the lay
 design live in [SECURITY_ARCHITECTURE.md](SECURITY_ARCHITECTURE.md).
 
 `targets.local` is **optional**: for ad-hoc local scans you can pass paths on the command
-line (`stayawake-security-scan <path>…` / `--path`), and a bare `stayawake-security-scan`
-with nothing configured scans the current repository. A token is never needed for local
+line (`saw scan <path>…` / `--path`), and a bare `saw scan` with nothing configured scans
+the current repository. A token is never needed for local
 scanning — see [USAGE.md](USAGE.md#ad-hoc-local-scanning-no-token-no-config).
 
 Each `allowlist` entry **must name a `signature`** (optionally scoped by `path_glob`) — a

--- a/docs/PREREQUISITES.md
+++ b/docs/PREREQUISITES.md
@@ -29,5 +29,5 @@ The console scripts and configuration are described in [USAGE.md](USAGE.md).
 A prebuilt image is published to GHCR, so Docker alone is enough:
 
 ```bash
-docker run --rm ghcr.io/ndevu12/stayawakebot:latest stayawake-security-scan --help
+docker run --rm ghcr.io/ndevu12/stayawakebot:latest saw scan --help
 ```

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -63,12 +63,12 @@ the OIDC exchange is rejected.
    # TestPyPI lacks our deps, so allow PyPI as a fallback index:
    pip install --index-url https://test.pypi.org/simple/ \
                --extra-index-url https://pypi.org/simple/ stayawakebot
-   stayawake-security-scan --help
+   saw scan --help
    ```
 3. Tag and push:
    ```bash
-   git tag v0.1.0          # version is derived from this tag by hatch-vcs
-   git push origin v0.1.0
+   git tag v0.1.0          # MUST be vX.Y.Z (a malformed tag like v.1.4 yields a dev/local
+   git push origin v0.1.0  # version PyPI rejects); hatch-vcs derives the version from this tag
    ```
 4. Approve the `pypi` environment deployment when prompted.
 5. The workflow publishes to PyPI (with PEP 740 attestations) and creates the GitHub Release
@@ -80,7 +80,7 @@ the OIDC exchange is rejected.
 - Clean-room install:
   ```bash
   pip install stayawakebot==<version>
-  stayawake-security-scan --help
+  saw scan --help
   ```
 - `pip download stayawakebot==<version>` then `twine check` the artifacts.
 
@@ -142,7 +142,7 @@ version via `--build-arg VERSION` → `SETUPTOOLS_SCM_PRETEND_VERSION` (the gene
 
 Verify a published image:
 ```bash
-docker run --rm ghcr.io/ndevu12/stayawakebot:<version> stayawake-security-scan --help
+docker run --rm ghcr.io/ndevu12/stayawakebot:<version> saw scan --help
 docker buildx imagetools inspect ghcr.io/ndevu12/stayawakebot:<version>   # see provenance/SBOM
 ```
 

--- a/docs/SECURITY_ARCHITECTURE.md
+++ b/docs/SECURITY_ARCHITECTURE.md
@@ -63,8 +63,10 @@ signatures (data) ─► signature engine ─► matchers ─► findings ─►
 - `security/cli/report.py` · `security/cli/alert.py` · `security/cli/remediate.py` — report, alert, remediate.
 - `security/cli/audit.py` (+ `security/hygiene.py`) — local posture + branch-protection audit.
 
-Installed as console scripts: `stayawake-security-scan` · `-report` · `-alert` · `-remediate` · `-audit`
-(or `python -m stayawake.bots.security.cli.<action>`).
+Run via the terse **`saw`** CLI: `saw scan` · `saw report` · `saw alert` · `saw fix` · `saw audit`
+(and `saw run` for the scan→report→alert pipeline) — see the [CLI guide](CLI.md). The legacy
+`stayawake-security-*` console scripts remain installed (frozen for CI/Docker) and route to the
+same code.
 
 ## Testing
 `tests/bots/security/` — inert fixtures (clean vs infected) covering every matcher, plus a real
@@ -72,19 +74,19 @@ evil-merge git fixture. Run (package installed): `python -m unittest discover -s
 
 ## Remediation
 
-`stayawake-security-remediate [--apply]` — dry-run by default. With
+`saw fix [--apply]` — dry-run by default. With
 `--apply` it strips/quarantines worm artifacts (originals backed up to `.malware-quarantine/`)
 and commits the fix to a `security/auto-clean-<stamp>` branch — never main, never force-pushed.
 Evil-merge findings are reported as manual (need a history rewrite).
 
-`--apply --open-pr` pushes a stable `security/auto-clean` branch and opens **one rolling
+`--apply --pr` pushes a stable `security/auto-clean` branch and opens **one rolling
 PR per repo**, targeting the default branch for review. Before opening it checks the API for
 an existing open PR from that branch and updates it instead of creating a duplicate. Work is
 isolated in a git worktree; it never commits to or force-pushes the default branch. After
 applying, it **re-scans and aborts (no PR) if anything is still detected**, and the commit
 message / PR body describe only what was *actually* changed.
 
-`stayawake-security-audit [--repo owner/name]` checks local posture (cached GitHub credential,
+`saw audit [--repo owner/name]` checks local posture (cached GitHub credential,
 VS Code auto-run / Workspace Trust) and, with a token + `--repo`, that the default branch is
 protected and the **Worm Guard** check is required.
 
@@ -116,7 +118,7 @@ wasteful and reactive.
 |-------|---------|-----------|
 | Hosted — gate | `pull_request` + `push` (code paths) | `worm-guard` blocks infection from landing (read-only, fail-on-findings) |
 | Hosted — sentinel | `push` to `main` (merge) + `workflow_dispatch` + weekly backstop | scan the repo, refresh status, alert, commit report |
-| Local — CLI | on demand | `stayawake-security-scan` over all dev roots; `stayawake-security-remediate [--apply] [--open-pr]` fixes each repo |
+| Local — CLI | on demand | `saw scan` over all dev roots; `saw fix [--apply] [--pr]` fixes each repo |
 | Availability | `schedule` (*/5) | uptime genuinely needs polling — the one place a clock is correct |
 
 Org-wide coverage is **distributed**: every repo runs its own `worm-guard` on its own

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -25,7 +25,7 @@ command; mount the repository to scan at `/repo`:
 
 ```bash
 docker run --rm -v "$PWD:/repo:ro" ghcr.io/ndevu12/stayawakebot \
-  stayawake-security-scan --local-only --fail-on-findings
+  saw scan --local --fail
 docker run --rm ghcr.io/ndevu12/stayawakebot stayawake-health-check --help
 ```
 
@@ -37,7 +37,7 @@ To keep the report on the host, mount a writable dir and run as your own user:
 ```bash
 docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/repo" \
   ghcr.io/ndevu12/stayawakebot \
-  stayawake-security-scan --local-only --reports-dir /repo/reports
+  saw scan --local --reports-dir /repo/reports
 ```
 
 Pin a version (`ghcr.io/ndevu12/stayawakebot:0.1.0`) or a commit (`:sha-<commit>`) for
@@ -66,10 +66,14 @@ stayawake-health-check --config config/urls.yml --fail-on-unhealthy
 
 ## Security bot — worm hunting
 
+The local security CLI is **`saw`** (see the [CLI guide](CLI.md)). Run the stages individually,
+or `saw run` to do scan → report → alert in one pass:
+
 ```bash
-stayawake-security-scan --config config/security.yml --local-only   # scan local repos → reports/security/latest.json
-stayawake-security-report                                           # write security status.json
-stayawake-security-alert                                            # Slack + GitHub issue on findings
+saw scan --config config/security.yml --local   # scan local repos → reports/security/latest.json
+saw report                                       # write security status.json
+saw alert                                        # Slack + GitHub issue on findings
+saw run                                          # …or all three at once
 ```
 
 ### Ad-hoc local scanning (no token, no config)
@@ -79,26 +83,26 @@ for cloning private remotes or opening PRs. Point the scanner at paths, or just 
 inside a repo:
 
 ```bash
-stayawake-security-scan                      # no args → scans the repo you're standing in
-stayawake-security-scan ~/dev/some-project   # scan a specific repo (or a folder of repos)
-stayawake-security-scan ./a ./b --path ./c   # several at once (positional and/or --path)
+saw scan                      # no args → scans the repo you're standing in
+saw scan ~/dev/some-project   # scan a specific repo (or a folder of repos)
+saw scan ./a ./b --path ./c   # several at once (positional and/or --path)
 ```
 
 A path may be a single repository or a directory containing many — the scanner walks it
-for git repos. Explicit paths imply `--local-only` (nothing is sent to GitHub). With no
+for git repos. Explicit paths imply `--local` (nothing is sent to GitHub). With no
 paths and nothing configured, it scans the current repository (found by walking up to the
-nearest `.git`), so a bare `stayawake-security-scan` "just works" after `pip install`.
+nearest `.git`), so a bare `saw scan` "just works" after `pip install`.
 
 Remediation is **safe by default (dry-run)**:
 
 ```bash
-stayawake-security-remediate                    # dry-run: show what would be fixed
-stayawake-security-remediate --apply            # strip/quarantine worm artifacts on a security/auto-clean branch
-stayawake-security-remediate --apply --open-pr  # also open one rolling PR per repo
-stayawake-security-remediate --remote           # operate on remote GitHub targets from config
+saw fix                    # dry-run: show what would be fixed
+saw fix --apply            # strip/quarantine worm artifacts on a security/auto-clean branch
+saw fix --apply --pr       # also open one rolling PR per repo
+saw fix --remote           # operate on remote GitHub targets from config
 ```
 
-**Read-only fallback (remediation ladder):** when `--open-pr` / `--remote` can't push a
+**Read-only fallback (remediation ladder):** when `--pr` / `--remote` can't push a
 fix branch (you only have read access to the target), StayAwakeBot doesn't discard the
 fix — it degrades down a ladder:
 
@@ -112,8 +116,8 @@ fix — it degrades down a ladder:
 So remediation always produces something actionable — a fork PR, a patch, a heads-up, or
 some combination — even without write access to the target.
 
-Drop `--local-only` to also scan the GitHub users/orgs listed in `config/security.yml`.
-Use `--fail-on-findings` to make `scan` exit non-zero (the CI gate uses this).
+Drop `--local` to also scan the GitHub users/orgs listed in `config/security.yml`.
+Use `--fail` to make `scan` exit non-zero (for CI gating).
 See [SECURITY_ARCHITECTURE.md](SECURITY_ARCHITECTURE.md) for how detection / remediation work.
 
 Reports go to `reports/security/` by default. To run a scan **without touching the
@@ -121,8 +125,8 @@ committed reports** (local experiments, CI, scanning someone else's repo), redir
 output — via `--reports-dir` or `settings.reports_dir` in config:
 
 ```bash
-stayawake-security-scan --local-only --reports-dir /tmp/sab-reports   # writes only there
-stayawake-health-check  --reports-dir /tmp/sab-reports                # same for the health bot
+saw scan --local --reports-dir /tmp/sab-reports                      # writes only there
+stayawake-health-check  --reports-dir /tmp/sab-reports               # same for the health bot
 ```
 
 ## Local defense-in-depth (hooks + audit)
@@ -147,8 +151,8 @@ Audit the machine's security posture (cached GitHub credential, VS Code auto-run
 Workspace Trust), and optionally a repo's branch-protection gate:
 
 ```bash
-stayawake-security-audit                       # advisory; add --fail-on-issues for scripts/CI
-stayawake-security-audit --repo owner/name     # also check that Worm Guard is a required check
+saw audit                       # advisory; add --fail for scripts/CI
+saw audit --repo owner/name     # also check that Worm Guard is a required check
 ```
 
 `--repo` needs a GitHub credential (an env token or a `gh auth login` session — see
@@ -193,13 +197,13 @@ scope is in parentheses):
 
 | Command | Needs a token? | Permission (classic) |
 | --- | --- | --- |
-| `stayawake-security-scan <path>` / public remotes | no | — |
-| `stayawake-security-scan` private remotes | read | Contents + Metadata: Read (`repo`) |
-| `stayawake-security-remediate --open-pr` / `--remote` | write | Contents + Pull requests: R/W (`repo`) |
+| `saw scan <path>` / public remotes | no | — |
+| `saw scan` private remotes | read | Contents + Metadata: Read (`repo`) |
+| `saw fix --pr` / `--remote` | write | Contents + Pull requests: R/W (`repo`) |
 | ↳ fork fallback (cross-fork PR when you can't push upstream) | fork + PR | Pull requests: R/W on your fork (`public_repo` / `repo`) |
 | ↳ patch/issue fallback (no write at all) | none / issues | Issues: R/W for the notify issue (`repo` / `public_repo`); patch needs nothing |
-| `stayawake-security-alert` (GitHub issue) | write | Issues: R/W (`repo` / `public_repo`) |
-| `stayawake-security-audit --repo` | read | Administration: Read (`repo`) |
+| `saw alert` (GitHub issue) | write | Issues: R/W (`repo` / `public_repo`) |
+| `saw audit --repo` | read | Administration: Read (`repo`) |
 
 ### GitHub App (organization **or** personal account)
 
@@ -224,8 +228,8 @@ export GH_APP_ID=123456
 export GH_APP_PRIVATE_KEY="$(cat your-app.private-key.pem)"   # or GH_APP_PRIVATE_KEY_PATH=…
 # optional; auto-detected when the App has exactly one installation:
 export GH_APP_INSTALLATION_ID=98765
-stayawake-security-scan               # scans every repo the installation can see
-stayawake-security-remediate --remote # opens a dedup'd fix PR per infected install repo
+saw scan               # scans every repo the installation can see
+saw fix --remote       # opens a dedup'd fix PR per infected install repo
 ```
 
 If the App env is set without the extra installed, StayAwakeBot prints a clear


### PR DESCRIPTION
## What

The `saw` CLI shipped in v0.1.4, but the documentation still showed the long `stayawake-security-*` commands. This updates the example commands across the docs to use `saw`.

| File | Change |
|---|---|
| README.md | Quick-start + Docker examples → `saw scan`; link `docs/CLI.md`; refresh the back-compat note |
| docs/USAGE.md | Security bot section, ad-hoc scanning, remediation, reports-dir, audit, token-scope table, GitHub App examples → `saw` |
| docs/SECURITY_ARCHITECTURE.md | Console-script line, remediation, audit, and the local-CLI table row → `saw` |
| docs/ARCHITECTURE.md | Install & run security lines → `saw` |
| docs/CONFIGURATION.md · docs/PREREQUISITES.md | Ad-hoc scan / Docker example → `saw` |
| docs/RELEASING.md | Smoke-test + verify commands → `saw`; add a `vX.Y.Z` tag-format note |
| Dockerfile | Comment examples + default `CMD` → `saw --help` |

Flag spellings updated to the new forms: `--local-only`→`--local`, `--fail-on-findings`/`--fail-on-issues`→`--fail`, `--open-pr`→`--pr`.

## Deliberately NOT changed

- **`stayawake-health-*`** — health is a separate, remote-only bot with no `saw` command.
- **GitHub Actions / CI and the `strix` Action descriptions** — they intentionally call the frozen legacy scripts.
- **Explicit back-compat mentions** of the legacy `stayawake-security-*` scripts (they still work).

## Verification

Every `saw` command/flag used in the docs was validated against the installed CLI (`saw … --help` → exit 0 for scan/run/report/alert/fix/audit/search/doctor with the documented flags).