### PR TITLE
fix(security): remove evil-merge & oversized-line false positives (#1052)

### DIFF
--- a/src/stayawake/bots/security/data/signatures.yml
+++ b/src/stayawake/bots/security/data/signatures.yml
@@ -96,6 +96,20 @@ signatures:
     description: "Config file with an abnormally long single line (likely appended payload)"
     remediation: strip-appended-payload
 
+  # ── Whole-file obfuscation (line-agnostic, context-scoped) ───────────────────
+  # Closes G4: a payload SPLIT/WRAPPED across many <2000-char lines, or living in
+  # .jsx/.tsx/.vue/.svelte, defeats the formatting-keyed oversized-config-line rule.
+  # This signature runs loader fingerprints + a context-scoped obfuscation detector
+  # over the RAW file content (not splitlines) for hand-authored source/config only;
+  # vendored/minified/generated paths are suppressed by the matcher's context gate.
+  - id: obfuscated-source-file
+    category: code-loader
+    severity: medium
+    matcher: obfuscation
+    kind: obfuscated-file
+    description: "Hand-authored source/config file containing packed/obfuscated payload (line-agnostic)"
+    remediation: strip-appended-payload
+
   # ── VS Code auto-run harness (structured JSON) ───────────────────────────────
   - id: vscode-task-folderopen-exec
     category: vscode-autorun

--- a/src/stayawake/bots/security/matchers/__init__.py
+++ b/src/stayawake/bots/security/matchers/__init__.py
@@ -11,11 +11,12 @@ from stayawake.bots.security.matchers.filename import FilenameMatcher
 from stayawake.bots.security.matchers.structural import StructuralJsonMatcher
 from stayawake.bots.security.matchers.heuristic import HeuristicMatcher
 from stayawake.bots.security.matchers.git_history import GitHistoryMatcher
+from stayawake.bots.security.matchers.obfuscation import ObfuscationMatcher
 
 REGISTRY: dict[str, Matcher] = {
     m.handles: m for m in (
         ContentMatcher(), FilenameMatcher(), StructuralJsonMatcher(),
-        HeuristicMatcher(), GitHistoryMatcher(),
+        HeuristicMatcher(), GitHistoryMatcher(), ObfuscationMatcher(),
     )
 }
 

--- a/src/stayawake/bots/security/matchers/base.py
+++ b/src/stayawake/bots/security/matchers/base.py
@@ -32,6 +32,28 @@ def globs_ok(relpath: str, sig: dict[str, Any]) -> bool:
     return any(fnmatch(relpath, g) or fnmatch(base, g) for g in globs)
 
 
+def build_content_sig(signatures: list[dict[str, Any]]):
+    """Compile the worm CONTENT-loader fingerprints (the `content` matcher's code-loader
+    regex signatures) into one callable `check(text) -> signature_id | None`.
+
+    Matches against the text AND its newline-flattened form, so a payload wrapped across
+    lines still hits. Used wherever a matcher corroborates a structural signal (a long
+    line, a merge-introduced hunk) against "is this actually a known loader" without
+    re-running a full file scan. Patterns come from the live signature DB so the two never
+    drift. Shared by the evil-merge, heuristic and obfuscation matchers (one source)."""
+    pats = [(s["id"], re.compile(s["pattern"], re.IGNORECASE))
+            for s in signatures if s.get("pattern") and s.get("category") == "code-loader"]
+
+    def check(text: str):
+        flat = text.replace("\n", "").replace("\r", "")
+        for sid, rx in pats:
+            if rx.search(text) or rx.search(flat):
+                return sid
+        return None
+
+    return check
+
+
 def load_jsonc(text: str) -> Any:
     try:
         return json.loads(text)

--- a/src/stayawake/bots/security/matchers/git_history.py
+++ b/src/stayawake/bots/security/matchers/git_history.py
@@ -4,26 +4,43 @@ from __future__ import annotations
 
 from stayawake.core import git as gitutil
 from stayawake.bots.security.models import Finding, Severity
-from stayawake.bots.security.matchers.base import Matcher
+from stayawake.bots.security.matchers.base import Matcher, build_content_sig
+
+
+# Bound on the EXPENSIVE per-candidate merge-tree confirmation phase (defense in depth
+# for pathological repos with tens of thousands of genuine conflict-resolution merges).
+# This caps post-prefilter *candidates*, NOT raw merges. `merge_commits` drops only true
+# no-op merges (empty first-parent diff), so a buried evil merge — newest-first ordered —
+# stays well within the cap and the G1 "buried behind many merges" case is always reached.
+# Set high enough that no real repository ever hits it.
+_MAX_CANDIDATES = 2000
 
 
 class GitHistoryMatcher(Matcher):
     handles = "git-history"
 
-    def scan(self, target, signatures):
+    def scan(self, target, signatures, all_signatures=None):
         sig = next((s for s in signatures if s.get("kind") == "evil-merge"), None)
         if not sig or not gitutil.is_git_repo(target.repo_root):
             return []
+        # Corroborate the merge-introduced hunk against worm loader fingerprints. The
+        # content signatures live in their own matcher group; the scanner passes the full
+        # signature set as `all_signatures` so we can reach them. Fall back to the
+        # git-history group (loaders absent) when not provided.
+        content_sig = build_content_sig(all_signatures or signatures)
         findings: list[Finding] = []
-        for sha in gitutil.merge_commits(target.repo_root):
-            evil = gitutil.evil_merge_paths(target.repo_root, sha)
+        for sha in gitutil.merge_commits(target.repo_root)[:_MAX_CANDIDATES]:
+            evil = gitutil.evil_merge_paths(target.repo_root, sha, content_sig=content_sig)
             if evil:
                 meta = gitutil.commit_meta(target.repo_root, sha)
+                paths = sorted(evil)
+                why = evil[paths[0]]
                 findings.append(Finding(
                     signature_id=sig["id"], category=sig["category"],
                     severity=Severity.parse(sig["severity"]), path=sha[:10],
                     description=sig["description"], remediation=sig.get("remediation", "manual"),
-                    evidence=f"{len(evil)} path(s) introduced beyond a clean 3-way merge; "
-                             f"e.g. {sorted(evil)[:3]}; by {meta.get('author_email','?')}",
+                    evidence=f"{len(evil)} corroborated path(s) introduced beyond a clean "
+                             f"3-way merge; e.g. {paths[:3]} ({why}); "
+                             f"by {meta.get('author_email','?')}",
                     vector="evil-merge"))
         return findings

--- a/src/stayawake/bots/security/matchers/heuristic.py
+++ b/src/stayawake/bots/security/matchers/heuristic.py
@@ -1,32 +1,76 @@
 #!/usr/bin/env python3
-"""Heuristic matcher — oversized lines and text-in-fontfile detection."""
+"""Heuristic matcher — oversized lines and text-in-fontfile detection.
+
+The `oversized-config-line` rule is the formatting-keyed signal for an appended/packed
+payload in a hand-authored config. Raw line length is NOT decisive on its own: real
+configs legitimately carry one very long line (a tailwind `safelist`, an eslint
+`globals` object, an inlined `data:` URI, a long proxy URL). So the long-line signal is
+CORROBORATED with the context-aware confidence lever (G5): a long line is reported only
+when (a) the file's content carries a worm loader fingerprint, OR (b) the file is
+context-scoped obfuscated/packed per `analyze_file` (high-entropy, packed-shape,
+density-dominant — after stripping inline `data:` asset URIs). Vendored/minified/
+generated paths are suppressed there, so dense bundles never reach this rule.
+"""
 from __future__ import annotations
 
 from stayawake.bots.security.models import Finding, Severity
-from stayawake.bots.security.matchers.base import Matcher, globs_ok, FONT_MAGIC
+from stayawake.bots.security.matchers.base import Matcher, globs_ok, FONT_MAGIC, build_content_sig
+from stayawake.bots.security.obfuscation import (
+    analyze_file, is_generated_context, _AUTHORED_OBFUSCATABLE_EXTS,
+)
+from stayawake.bots.security.matchers.obfuscation import _ext
 
 
 class HeuristicMatcher(Matcher):
     handles = "heuristic"
 
-    def scan(self, target, signatures):
+    def scan(self, target, signatures, all_signatures=None):
         findings: list[Finding] = []
         long_line = next((s for s in signatures if s.get("kind") == "long-line"), None)
         text_font = next((s for s in signatures if s.get("kind") == "text-in-fontfile"), None)
+        content_sig = build_content_sig(all_signatures or signatures)
         for rel in target.iter_files():
             if long_line and globs_ok(rel, long_line):
-                text = target.read_text(rel)
-                if text is not None:
-                    th = int(long_line.get("threshold", 2000))
-                    for i, ln in enumerate(text.splitlines(), 1):
-                        if len(ln) > th:
-                            findings.append(self._emit(long_line, rel, f"line {i}: {len(ln)} chars", i))
-                            break
+                f = self._oversized_line(target, rel, long_line, content_sig)
+                if f:
+                    findings.append(f)
             if text_font and globs_ok(rel, text_font):
                 f = self._disguised_font(target, rel, text_font)
                 if f:
                     findings.append(f)
         return findings
+
+    def _oversized_line(self, target, rel, sig, content_sig):
+        """Emit only a CORROBORATED oversized-line finding (G5). Scan ALL long lines on
+        the RAW content (no early break) so a head/tail-truncation splice can't hide a
+        long line behind a short first one; but require the file to be loader-fingerprinted
+        OR context-scoped obfuscated, so a legitimately long config line stays clean."""
+        text = target.read_text(rel)
+        if text is None:
+            return None
+        th = int(sig.get("threshold", 2000))
+        # The raw formatting signal: at least one line longer than the threshold.
+        long_hit = next(((i, len(ln)) for i, ln in enumerate(text.splitlines(), 1)
+                         if len(ln) > th), None)
+        if long_hit is None:
+            return None
+        # Context-aware corroboration. Generated/vendored paths are expected to carry long
+        # dense lines → never corroborated here (suppressed exactly as the obfuscation matcher).
+        if is_generated_context(rel):
+            return None
+        i, n = long_hit
+        # (a) worm loader fingerprint anywhere in the file's content.
+        hit = content_sig(text)
+        if hit:
+            return self._emit(sig, rel, f"line {i}: {n} chars; loader fingerprint: {hit}", i)
+        # (b) context-scoped obfuscation verdict (only meaningful for authored exts; the
+        #     globs already restrict to config/source extensions, but guard explicitly so
+        #     a future glob widening can't leak a non-authored ext into analyze_file).
+        if _ext(rel) in _AUTHORED_OBFUSCATABLE_EXTS:
+            verdict = analyze_file(text, _ext(rel))
+            if verdict:
+                return self._emit(sig, rel, f"line {i}: {n} chars; {verdict.reason}", i)
+        return None
 
     @staticmethod
     def _emit(sig, rel, ev, line=None):

--- a/src/stayawake/bots/security/matchers/obfuscation.py
+++ b/src/stayawake/bots/security/matchers/obfuscation.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Whole-file obfuscation matcher — line-AGNOSTIC payload detection (G4).
+
+The formatting-keyed long-line rule (heuristic `oversized-config-line`) only fires
+on a single line longer than its threshold. A payload that is SPLIT/WRAPPED onto
+many shorter lines, or that lives in an extension that rule doesn't cover
+(.jsx/.tsx/.vue/.svelte), slips straight past it. This matcher closes that gap: it
+runs the worm content-loader fingerprints AND a context-scoped obfuscation detector
+over the RAW concatenated file content — independent of any single line's length —
+for hand-authored source/config files.
+
+Context-aware confidence is the lever that keeps this FP-free: the detector is
+applied ONLY to hand-authored extensions and ONLY outside vendored/minified/generated
+locations (is_generated_context). In those generated paths obfuscation is expected
+and suppressed; in hand-authored source it is anomalous and reported.
+"""
+from __future__ import annotations
+
+from stayawake.bots.security.models import Finding, Severity
+from stayawake.bots.security.matchers.base import Matcher, build_content_sig
+from stayawake.bots.security.obfuscation import (
+    analyze_file,
+    is_generated_context,
+    _AUTHORED_OBFUSCATABLE_EXTS,
+)
+
+
+def _ext(rel: str) -> str:
+    i = rel.rfind(".")
+    return rel[i:].lower() if i != -1 else ""
+
+
+class ObfuscationMatcher(Matcher):
+    handles = "obfuscation"
+
+    def scan(self, target, signatures, all_signatures=None):
+        sig = next((s for s in signatures if s.get("kind") == "obfuscated-file"), None)
+        if not sig:
+            return []
+        content_sig = build_content_sig(all_signatures or signatures)
+        findings: list[Finding] = []
+        for rel in target.iter_files():
+            if _ext(rel) not in _AUTHORED_OBFUSCATABLE_EXTS:
+                continue
+            if is_generated_context(rel):       # vendored/minified/generated → obfuscation expected
+                continue
+            text = target.read_text(rel)
+            if not text:
+                continue
+            # (a) line-agnostic loader fingerprint on the raw content.
+            hit = content_sig(text)
+            if hit:
+                findings.append(self._emit(sig, rel, f"loader fingerprint on raw content: {hit}"))
+                continue
+            # (b) context-scoped whole-file obfuscation (split/wrapped packed payload).
+            verdict = analyze_file(text, _ext(rel))
+            if verdict:
+                findings.append(self._emit(sig, rel, verdict.reason))
+        return findings
+
+    @staticmethod
+    def _emit(sig, rel, ev):
+        return Finding(signature_id=sig["id"], category=sig["category"],
+                       severity=Severity.parse(sig["severity"]), path=rel,
+                       description=sig["description"], remediation=sig.get("remediation", "manual"),
+                       evidence=ev, vector=sig["category"])

--- a/src/stayawake/bots/security/obfuscation.py
+++ b/src/stayawake/bots/security/obfuscation.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Context-aware obfuscation analysis for a *delta* of source text.
+
+Single responsibility: decide whether a chunk of newly-introduced text in a
+hand-authored source file is obfuscated/packed payload, as opposed to ordinary
+hand-written code. The detector is deliberately delta-scoped: it judges ONLY the
+lines an edit introduced (e.g. the lines a merge slipped past review), compared
+against a *baseline* of the file's pre-edit text. That comparison is what makes a
+low-false-positive verdict possible — "this file suddenly became dense/minified"
+is a far stronger signal than any absolute threshold on a whole file.
+
+No I/O, no git, no regex catalogue duplication: callers pass in plain strings.
+
+Why these particular signals (each independently sufficient is too aggressive, so
+we require either a *self-evidently executable* obfuscation construct OR a
+*corroborated* density/entropy anomaly):
+
+  * charcode / hex numeric arrays  — `[104,116,116,112,...]`, `[0x68,0x74,...]`
+    feeding String.fromCharCode / apply: the canonical Shai-Hulud string shuffler
+    and the generic "build a string from numbers so no literal is greppable" trick.
+  * dynamic-exec sinks            — eval(, new Function(, atob(, Function(, the
+    require-hijack global['!']: code that turns decoded bytes back into execution.
+  * long base64 blob              — a single >=120-char [A-Za-z0-9+/=] run that is
+    not already plain text (most real code has spaces/punctuation breaking it up).
+  * minification spike            — the introduced text is one (or few) very long
+    lines AND the file's baseline was normally-formatted (short lines): a
+    previously hand-formatted file does not legitimately gain a 2 KB single line
+    in a merge/conflict resolution.
+  * entropy spike                 — Shannon entropy per char of the introduced
+    text is both high in absolute terms AND markedly above the file baseline:
+    packed/encoded payload looks random; prose and code do not.
+
+The verdict requires a dynamic-exec sink, OR a charcode/hex array, OR a base64
+blob, OR (minification spike AND entropy spike together). A lone high-entropy or
+lone long-line signal is NOT enough — that is exactly the benign "long config
+value" / "generated data line" shape, and is left to corroborate elsewhere.
+"""
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass
+
+# A numeric array literal of >=8 elements, decimal or hex — the charcode/byte shuffler.
+_NUM_ARRAY = re.compile(r"\[\s*(?:0x[0-9a-fA-F]+|\d{1,3})\s*(?:,\s*(?:0x[0-9a-fA-F]+|\d{1,3})\s*){7,}\]")
+# Dynamic-execution sinks that turn decoded bytes back into running code.
+_EXEC_SINK = re.compile(
+    r"\beval\s*\(|new\s+Function\s*\(|\bFunction\s*\(\s*[\"']|\batob\s*\(|"
+    r"String\s*[.\[]\s*[\"']?fromCharCode|global\s*\[\s*['\"]!['\"]\s*\]\s*=",
+    re.IGNORECASE,
+)
+# A long unbroken base64-ish run not already broken up by code/prose punctuation.
+_B64_BLOB = re.compile(r"[A-Za-z0-9+/]{120,}={0,2}")
+# A self-describing inline asset (image/font/media data-URI). A base64 blob that is the
+# payload of a `data:<mime>;base64,` URI is a legitimate inlined asset, not obfuscated
+# code — so we exclude those runs before the base64-blob trigger to avoid that FP.
+_DATA_URI = re.compile(r"data:[\w.+-]+/[\w.+-]+;base64,[A-Za-z0-9+/]+={0,2}", re.IGNORECASE)
+# Minimum Shannon entropy a matched base64-blob run must itself carry to count as an
+# encoded payload. A real base64 blob is ~5.5-6.0 bits/char (uniform over 64 symbols);
+# a long *low-entropy* run that happens to be all [A-Za-z0-9+/] — e.g. a repeated-char
+# placeholder/path segment (`token=xxxxxxxx…`) or a single-token long URL — is NOT an
+# encoded payload and must not trip the blob trigger. This gate closes the long-URL FP
+# (G5) without weakening detection of genuine base64 (which clears it by a wide margin).
+_B64_BLOB_MIN_ENTROPY = 4.5
+
+# Minification: a single introduced line at/above this length in a file whose
+# baseline lines were comfortably shorter. Kept well under the 2000-char long-line
+# rule so a split/wrapped payload (G4) that dodges that rule is still caught here.
+_MINIFIED_LINE = 400
+_BASELINE_TYPICAL_MAX = 200  # a normally-formatted source file's lines fit easily under this
+
+# Entropy: payload-grade randomness, AND clearly above the file's own baseline.
+_ENTROPY_ABS = 4.3           # bits/char; English prose ~4.0-4.5, but combined with the
+_ENTROPY_DELTA = 0.8         # delta-vs-baseline gate this only fires on packed/encoded text
+
+
+def _shannon(s: str) -> float:
+    if not s:
+        return 0.0
+    counts: dict[str, int] = {}
+    for ch in s:
+        counts[ch] = counts.get(ch, 0) + 1
+    n = len(s)
+    return -sum((c / n) * math.log2(c / n) for c in counts.values())
+
+
+# ── Context-aware suppression (the single source of truth) ───────────────────────
+# Paths where obfuscation/minification is EXPECTED, so dense/packed content is NOT
+# anomalous: vendored caches, generated bundles, source maps, minified assets. A
+# hand-authored *.config.* or a normal source file is deliberately NOT here — there
+# obfuscation is anomalous and must be flagged. core.git imports this so the merge
+# corroborator and the whole-file matcher share ONE predicate and never drift.
+_GENERATED_PATH = re.compile(
+    # Two arms, joined by `|`:
+    #  (1) DIRECTORY / slash-anchored segments — must sit at a path-component boundary
+    #      so `myvendor/` etc. do not match a partial word.
+    #  (2) FILENAME tokens (.min.js, .map, .generated., .pb.js, …) — these are suffix/
+    #      infix markers on the basename and must match ANYWHERE in the name, including
+    #      mid-filename (`gql.generated.ts`, `app.min.js`) where no `/` precedes the token.
+    r"(?:(?:^|/)("
+    r"\.yarn/(?:cache|releases|unplugged)/|"
+    r"node_modules/|vendor/|third[_-]?party/|"
+    r"dist/|build/|out/|coverage/|storybook-static/|\.output/|\.svelte-kit/|\.nuxt/|\.next/|"
+    r"generated/|__generated__/|"
+    # Machine-generated dependency lockfiles (exact basenames only — NOT all *.json/*.yaml).
+    # Their content is a single tool-emitted blob that routinely carries multi-kilobyte
+    # lines (integrity hashes, resolved URLs); obfuscation there is EXPECTED, and they are a
+    # prime `-X theirs` conflict-remerge surface, so the obfuscation corroborator must be
+    # suppressed. The `(^|/)` anchor keeps these at a path-component boundary.
+    r"package-lock\.json$|npm-shrinkwrap\.json$|yarn\.lock$|pnpm-lock\.yaml$|"
+    r"composer\.lock$|Cargo\.lock$|poetry\.lock$|Gemfile\.lock$|go\.sum$|bun\.lockb$"
+    r"))"
+    r"|(?:"
+    r"\.pnp\.[cm]?js$|\.min\.(?:js|css|mjs|cjs)$|\.map$|\.bundle\.js$|"
+    r"\.generated\.|\.pb\.(?:js|ts)$|\.graphql\.(?:js|ts)$"
+    r")",
+    re.IGNORECASE,
+)
+
+
+def is_generated_context(path: str) -> bool:
+    """True when `path` is a vendored/minified/generated location where obfuscation is
+    EXPECTED (the context-aware-confidence lever). Callers suppress the obfuscation
+    detector there so legitimate dense bundles never become findings."""
+    return bool(_GENERATED_PATH.search(path))
+
+
+# Extensions that are hand-authored source/config a human edits — where a packed/
+# obfuscated blob is anomalous. Source maps (.map) and *.min.* are NOT here; those
+# are caught (and suppressed) by is_generated_context instead. .json is excluded:
+# a long minified JSON data line is a common benign shape and would need its own FP
+# model; the worm's loader lives in executable modules, which this set covers.
+_AUTHORED_OBFUSCATABLE_EXTS = {
+    ".js", ".cjs", ".mjs", ".ts", ".mts", ".cts",
+    ".jsx", ".tsx", ".vue", ".svelte",
+}
+
+# Whole-file minification: a payload wrapped onto lines each well under the 2000-char
+# long-line threshold still produces lines FAR longer than a hand-authored file's
+# typical line, AND a big block of such lines. We require BOTH an outlier-long line
+# and that the dense region dominates the file, so an isolated legitimately-long line
+# (a URL, a license header, one inlined constant) does not trip it on its own.
+_OUTLIER_LINE = 400          # a single line this long in authored source is already unusual
+_DENSE_LINE = 220            # lines at/above this count toward the "packed region"
+_DENSE_CHARS_FRAC = 0.5      # packed region must be >=50% of the file's non-blank chars
+# Packed/minified/encoded payload has almost no whitespace and very long unbroken
+# token runs; natural-language prose (which also reaches ~4.3 bits/char) does NOT —
+# prose is ~15-18% spaces with short words. These gates separate the two so a long
+# repeated-prose template constant is not mistaken for packed code.
+_MAX_PROSE_SPACE_FRAC = 0.07   # packed code is <7% whitespace; prose is far above this
+_MIN_UNBROKEN_RUN = 200        # a >=200-char run with no whitespace is not human text
+
+
+def _has_b64_payload(text: str) -> bool:
+    """True if `text` contains a long unbroken base64-ish run that is ALSO high-entropy —
+    i.e. a genuinely encoded blob, not a long low-entropy [A-Za-z0-9+/] run such as a
+    repeated-char placeholder or a single-token URL. Callers must strip data-URIs first
+    (legit inlined assets) before calling this."""
+    for m in _B64_BLOB.finditer(text):
+        if _shannon(m.group(0)) >= _B64_BLOB_MIN_ENTROPY:
+            return True
+    return False
+
+
+def _longest_nonspace_run(s: str) -> int:
+    best = run = 0
+    for ch in s:
+        if ch.isspace():
+            run = 0
+        else:
+            run += 1
+            if run > best:
+                best = run
+    return best
+
+
+def analyze_file(text: str, ext: str = "") -> ObfuscationVerdict:
+    """Line-AGNOSTIC, baseline-free obfuscation verdict for a whole hand-authored
+    source/config file (G4). Run on the RAW concatenated content so a payload that is
+    SPLIT/WRAPPED across many <2000-char lines — which defeats the formatting-keyed
+    long-line rule — is still caught.
+
+    Two tiers, mirroring analyze_delta:
+      1) self-evidently executable obfuscation (charcode/byte array, dynamic-exec sink,
+         long unbroken base64 blob) — sufficient on its own, line-independent.
+      2) a corroborated whole-file minification+entropy anomaly: the file carries an
+         outlier-long line AND a dense packed region that dominates it AND the whole
+         file reads as high-entropy. This is the in-file analogue of analyze_delta's
+         "spike vs baseline": a hand-authored module is neither this dense nor this
+         random, so the conjunction is what keeps it FP-free.
+
+    Caller is responsible for context-scoping (skip is_generated_context paths) and
+    for restricting to authored extensions; this function judges content only.
+    """
+    body = text or ""
+    if not body.strip():
+        return ObfuscationVerdict(False, "")
+
+    # Tier 1 — self-evident constructs over the RAW content (never splitlines, so a
+    # wrapped charcode array / base64 blob spanning line breaks is still seen).
+    flat = body.replace("\n", "").replace("\r", "")
+    if _NUM_ARRAY.search(flat):
+        return ObfuscationVerdict(True, "charcode/byte numeric-array literal (string shuffler)")
+    if _EXEC_SINK.search(body):
+        return ObfuscationVerdict(True, "dynamic-exec sink (eval/Function/atob/fromCharCode)")
+    deassetted = _DATA_URI.sub("", flat)
+    if _has_b64_payload(deassetted):
+        return ObfuscationVerdict(True, "long unbroken base64 blob")
+
+    # Tier 2 — corroborated whole-file minification anomaly (the split-line payload, and
+    # G5: a loader-EVADED single long line in a real config file — packed/encoded content
+    # is anomalous in hand-authored config regardless of the worm's loader fingerprint).
+    # Strip inline-asset data-URIs FIRST: a `data:<mime>;base64,…` value is a legitimately
+    # inlined asset, and its blob would otherwise dominate the density/entropy of an
+    # otherwise-clean config line (the inline-data-URI FP). After removal, the residual
+    # config text is judged on its own merits.
+    de_body = _DATA_URI.sub("", body)
+    lines = de_body.splitlines()
+    longest = max((len(ln) for ln in lines), default=0)
+    if longest < _OUTLIER_LINE:
+        return ObfuscationVerdict(False, "")          # nothing line-dense enough to be packed
+    nonblank_chars = sum(len(ln) for ln in lines if ln.strip())
+    dense_chars = sum(len(ln) for ln in lines if len(ln) >= _DENSE_LINE)
+    dense_frac = (dense_chars / nonblank_chars) if nonblank_chars else 0.0
+    entropy = _shannon(de_body)
+    # Structural payload-vs-prose discriminator: natural-language prose also reaches
+    # ~4.3 bits/char, but it is whitespace-rich (~15-18% spaces, short words). Packed/
+    # minified/encoded code is whitespace-poor with very long unbroken token runs.
+    # Require BOTH a low space ratio AND a long unbroken run so a long prose template
+    # constant is never mistaken for packed code.
+    space_frac = (sum(1 for c in de_body if c == " " or c == "\t") / len(de_body)) if de_body else 0.0
+    unbroken = _longest_nonspace_run(de_body)
+    packed_shape = space_frac <= _MAX_PROSE_SPACE_FRAC and unbroken >= _MIN_UNBROKEN_RUN
+    if dense_frac >= _DENSE_CHARS_FRAC and entropy >= _ENTROPY_ABS and packed_shape:
+        return ObfuscationVerdict(
+            True,
+            f"packed/minified content ({longest}-char line, "
+            f"{dense_frac*100:.0f}% dense, {entropy:.1f} bits/char, "
+            f"{unbroken}-char unbroken run)",
+        )
+    return ObfuscationVerdict(False, "")
+
+
+@dataclass
+class ObfuscationVerdict:
+    obfuscated: bool
+    reason: str        # short, redaction-safe explanation for evidence strings
+
+    def __bool__(self) -> bool:
+        return self.obfuscated
+
+
+def analyze_delta(introduced: str, baseline: str = "") -> ObfuscationVerdict:
+    """Judge whether `introduced` (the newly-added text) is obfuscated payload,
+    using `baseline` (the file's pre-edit text, may be empty for a brand-new file)
+    to anchor the minification/entropy spikes.
+
+    Returns an ObfuscationVerdict; truthy iff obfuscated. Designed so that ordinary
+    code, prose, JSON, and normal conflict resolutions return False.
+    """
+    text = introduced or ""
+    if not text.strip():
+        return ObfuscationVerdict(False, "")
+
+    # 1) Self-evidently executable obfuscation constructs — sufficient on their own.
+    if _NUM_ARRAY.search(text):
+        return ObfuscationVerdict(True, "charcode/byte numeric-array literal (string shuffler)")
+    if _EXEC_SINK.search(text):
+        return ObfuscationVerdict(True, "dynamic-exec sink (eval/Function/atob/fromCharCode)")
+    # Strip self-describing inline assets (image/font data-URIs) before the base64 test:
+    # a `data:...;base64,...` payload is a legitimate inlined asset, not packed code.
+    deassetted = _DATA_URI.sub("", text)
+    if _has_b64_payload(deassetted):
+        return ObfuscationVerdict(True, "long unbroken base64 blob")
+
+    # 2) Corroborated density anomaly: a previously-formatted file that suddenly
+    #    gains a very long single line that ALSO reads as high-entropy packed text.
+    intro_lines = text.splitlines() or [text]
+    longest_intro = max((len(ln) for ln in intro_lines), default=0)
+    base_lines = baseline.splitlines() if baseline else []
+    base_typical = max((len(ln) for ln in base_lines), default=0)
+
+    minified_spike = (longest_intro >= _MINIFIED_LINE and base_typical <= _BASELINE_TYPICAL_MAX)
+
+    intro_entropy = _shannon(text)
+    base_entropy = _shannon(baseline) if baseline.strip() else 0.0
+    entropy_spike = (
+        intro_entropy >= _ENTROPY_ABS
+        and (base_entropy == 0.0 or intro_entropy - base_entropy >= _ENTROPY_DELTA)
+    )
+
+    if minified_spike and entropy_spike:
+        return ObfuscationVerdict(
+            True,
+            f"minified+high-entropy hunk ({longest_intro}-char line, "
+            f"{intro_entropy:.1f} bits/char vs baseline {base_entropy:.1f})",
+        )
+
+    return ObfuscationVerdict(False, "")

--- a/src/stayawake/bots/security/scanner.py
+++ b/src/stayawake/bots/security/scanner.py
@@ -6,11 +6,22 @@ executes scanned code). One responsibility: target in → ScanResult out.
 """
 from __future__ import annotations
 
+import inspect
 from fnmatch import fnmatch
 from typing import Any
 
 from stayawake.bots.security.models import Finding, ScanResult
 from stayawake.bots.security.matchers import REGISTRY
+
+
+def _accepts_all_signatures(matcher) -> bool:
+    """True if a matcher's `scan` opts into the cross-signature view (an
+    `all_signatures` keyword param). Keeps the call site backward-compatible with
+    matchers that take only (target, signatures)."""
+    try:
+        return "all_signatures" in inspect.signature(matcher.scan).parameters
+    except (ValueError, TypeError):
+        return False
 
 
 def _allowed(finding: Finding, allowlist: list[dict[str, Any]]) -> bool:
@@ -35,12 +46,19 @@ def _allowed(finding: Finding, allowlist: list[dict[str, Any]]) -> bool:
 def scan_target(target, signatures_by_matcher: dict[str, list[dict[str, Any]]],
                 allowlist: list[dict[str, Any]] | None = None) -> ScanResult:
     result = ScanResult(target=target.display, source=target.source)
+    # Flat view of every signature, so a matcher that corroborates against OTHER
+    # matchers' signatures (the evil-merge detector cross-checks the content-loader
+    # fingerprints) can reach them without re-loading the DB.
+    all_sigs = [s for group in signatures_by_matcher.values() for s in group]
     try:
         for matcher_name, sigs in signatures_by_matcher.items():
             matcher = REGISTRY.get(matcher_name)
             if not matcher:
                 continue
-            for finding in matcher.scan(target, sigs):
+            findings = (matcher.scan(target, sigs, all_signatures=all_sigs)
+                        if _accepts_all_signatures(matcher)
+                        else matcher.scan(target, sigs))
+            for finding in findings:
                 if not _allowed(finding, allowlist or []):
                     result.findings.append(finding)
         # Stable, useful ordering: severity desc, then path.

--- a/src/stayawake/core/git.py
+++ b/src/stayawake/core/git.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import contextlib
 import os
+import re
 import stat
 import subprocess
 import tempfile
@@ -83,10 +84,83 @@ def is_git_repo(repo: str | Path) -> bool:
     return _run(repo, ["rev-parse", "--is-inside-work-tree"]).strip() == "true"
 
 
-def merge_commits(repo: str | Path, max_count: int = 200) -> list[str]:
-    """SHAs of merge commits (>=2 parents), newest first."""
-    out = _run(repo, ["rev-list", "--merges", f"--max-count={max_count}", "--all"])
-    return [s for s in out.split() if s]
+# Reachability scope for merge enumeration (G6 resolution).
+#
+# Chosen scope = local branches + tags + remote-tracking refs; deliberately:
+#   - NOT `--all`: `--all` ALSO walks refs/stash (every `git stash` is a 2/3-parent merge
+#     commit — the canonical FP), refs/notes, refs/replace and fetched forge PR refs
+#     (refs/pull/*), none of which a legitimate publish surface uses; all inflate FPs/cost.
+#   - WITH `--remotes`, NOT just `--branches --tags`: an evil merge can live ONLY on a
+#     remote-tracking ref the user has FETCHED (refs/remotes/origin/*) without yet merging
+#     it into a local branch. That object is already in the local store and is a genuine
+#     local compromise; `--branches --tags` alone cannot reach it (no local branch contains
+#     it) and would MISS it. `--remotes` reaches it.
+#
+# Why `--remotes` does NOT re-FP on unauthored origin merges: the evil-merge gate is
+# CONTENT-keyed (`_corroborated`), not ref-keyed. A benign origin-only merge carries no
+# worm signature / no new-vs-all-parents inject / no context-aware obfuscation, so it
+# survives enumeration but produces ZERO findings. Breadth only adds *candidates*; benign
+# candidates are silently discarded by the gate. (Empirically verified against benign vs
+# evil remote-only merges; see tests/bots/security/test_evil_merge.py G6 cases.)
+#
+# Cost/dedup: `git log` deduplicates by commit SHA, so a merge reachable from both a local
+# branch and a remote-tracking ref is enumerated exactly once — `--remotes` adds no
+# duplicate cost in the common (local==origin) case; it only adds genuinely-extra
+# remote-only commits, which is exactly the recall we want. The `_MAX_CANDIDATES` cap in
+# the matcher bounds the confirm phase even on a busy upstream with many merges.
+#
+# One ref family per token.
+_MERGE_REFS = ("--branches", "--tags", "--remotes")
+
+
+def merge_commits(repo: str | Path, refs: tuple[str, ...] = _MERGE_REFS) -> list[str]:
+    """SHAs of merge commits that are *candidates* for an evil merge — ALL of them,
+    with no count cap (closes the G1 "merge buried behind N newer merges" miss).
+
+    Enumeration is one git process: `git log --merges --diff-merges=first-parent
+    --name-only` emits, per merge, the FIRST-PARENT diff (the change the merge brought
+    onto the mainline a reviewer follows). A merge whose first-parent diff is EMPTY
+    changed nothing relative to mainline (a redundant/ff-equivalent merge) and cannot
+    smuggle content, so it is dropped here before any merge-tree cost is paid. Every
+    other merge survives as a candidate for `evil_merge_paths` to confirm (and discard
+    via the corroboration gate if benign).
+
+    Why `--diff-merges=first-parent` and NOT `-m --first-parent`: `--first-parent`
+    restricts *traversal* to the mainline chain, so an evil merge that lives INSIDE a
+    merged side-branch (reachable only through a second parent) would never be
+    enumerated. `--diff-merges=first-parent` sets only the per-merge DIFF FORMAT and
+    leaves traversal walking every merge — closing that miss while keeping the
+    first-parent (byte-identity-agnostic, see G2 below) diff. (Needs git >= 2.31; the
+    precise `evil_merge_paths` path already needs >= 2.38.)
+
+    G2 — why NOT the combined diff (`-c`): the combined diff lists only paths that
+    differ from **every** parent, so it is EMPTY for an octopus that pulls in a
+    payload-carrying head (the payload is byte-identical to that parent) and for a
+    2-parent `-X theirs`/conflict resolution that takes one side's payload verbatim.
+    Prefiltering on it silently dropped exactly those evil merges before confirmation.
+    The first-parent diff is byte-identity-agnostic and keeps them.
+
+    Cost: enumeration is one history walk; the per-candidate merge-tree confirm in
+    `evil_merge_paths` then runs on the survivors. The first-parent diff is non-empty
+    for nearly every real merge, so this trades the combined-diff prefilter's
+    aggressive (but unsound) drop for correctness; the `_MAX_CANDIDATES` cap in the
+    matcher bounds the confirm phase on pathological repositories.
+    """
+    out = _run(repo, ["log", "--merges", *refs, "--diff-merges=first-parent",
+                      "--name-only", "--format=%x01%H"])
+    candidates: list[str] = []
+    cur: str | None = None
+    nonempty = False
+    for line in out.splitlines():
+        if line.startswith("\x01"):              # record boundary: start of a new merge
+            if cur and nonempty:
+                candidates.append(cur)
+            cur, nonempty = line[1:].strip(), False
+        elif line.strip():                       # a path in this merge's first-parent diff
+            nonempty = True
+    if cur and nonempty:
+        candidates.append(cur)
+    return candidates
 
 
 def parents(repo: str | Path, sha: str) -> list[str]:
@@ -124,35 +198,164 @@ def _auto_merge_tree(repo: str | Path, a: str, b: str) -> str | None:
     return oid if is_oid else None
 
 
-def evil_merge_paths(repo: str | Path, merge_sha: str) -> set[str]:
-    """Paths whose content the merge introduced BEYOND a clean 3-way merge of its parents.
+def _is_generated_context(path: str) -> bool:
+    """True when `path` is a vendored/minified/generated location where obfuscation is
+    EXPECTED (the context-aware-confidence lever): suppress the obfuscation corroborator
+    there so legitimate dense bundles never become evil-merge findings.
+
+    Delegates to the single shared predicate in the security package so the merge
+    corroborator and the whole-file obfuscation matcher use ONE source of truth and
+    never drift. Imported lazily to keep core.git free of a hard security dependency."""
+    from stayawake.bots.security.obfuscation import is_generated_context
+    return is_generated_context(path)
+
+
+def path_exists_at(repo: str | Path, treeish: str, path: str) -> bool:
+    """True if `path` exists at a commit/tree (presence only — independent of whether the
+    blob is text or binary). Used by the new-vs-ALL-parents corroborator so a binary file
+    that decodes to '' is never mistaken for an absent file."""
+    res = _run_full(repo, ["cat-file", "-e", f"{treeish}:{path}"])
+    return res is not None and res.returncode == 0
+
+
+def file_at(repo: str | Path, treeish: str, path: str) -> str:
+    """Contents of `path` at a commit/tree (empty string if absent or binary-unreadable)."""
+    res = _run_full(repo, ["cat-file", "-p", f"{treeish}:{path}"])
+    if res is None or res.returncode != 0 or not res.stdout:
+        return ""
+    return res.stdout
+
+
+def introduced_added_text(repo: str | Path, base_tree: str, target: str, path: str) -> str:
+    """The text the diff `base_tree..target` ADDS to `path` — i.e. the merge-introduced
+    hunk's `+` lines, with the leading `+` stripped and diff `+++` headers excluded.
+
+    This is the review-evading content itself: the lines present in the recorded merge
+    but NOT in the clean auto-merge of its parents. We analyse exactly this delta (never
+    the whole file) so a benign conflict resolution that only re-arranges existing code
+    contributes nothing for the obfuscation detector to trip on."""
+    out = _run(repo, ["diff", "--unified=0", "--no-color", base_tree, target, "--", path])
+    added: list[str] = []
+    for line in out.splitlines():
+        if line.startswith("+++"):
+            continue
+        if line.startswith("+"):
+            added.append(line[1:])
+    return "\n".join(added)
+
+
+def _corroborated(repo: str | Path, base_tree: str, merge_sha: str, path: str,
+                  parent_shas: list[str], content_sig=None) -> tuple[bool, str]:
+    """Decide whether an introduced path is a CORROBORATED evil-merge signal, returning
+    (corroborated, reason). A raw "this path deviates from the auto-merge" is NOT enough —
+    benign conflict resolutions deviate too. We require one of:
+
+      (a) NEW-vs-ALL-PARENTS — the path exists in the merge but in NONE of its parents.
+          Such a file is structurally review-evading: no parent's PR diff shows it,
+          regardless of its content. (Catches the classic injected-file evil merge.)
+      (b) The merge-INTRODUCED hunk matches a worm content signature (loader fingerprint).
+      (c) The merge-INTRODUCED hunk is OBFUSCATED relative to the file's pre-merge baseline
+          (G3) — context-aware: suppressed in vendored/generated paths where obfuscation
+          is expected; applied only to the introduced delta in hand-authored source.
+
+    `content_sig` is an optional callable(text)->reason|None used for (b); kept injectable
+    so this module stays free of the signature-DB import.
+    """
+    # (a) new vs ALL parents — content-agnostic, formatting-agnostic (presence test, so a
+    #     binary file present in a parent is never misread as absent).
+    if all(not path_exists_at(repo, p, path) for p in parent_shas):
+        return True, "introduced file absent from every parent (review-evading)"
+
+    # The review-evading hunk, measured against the auto-merge tree (what merging the
+    # parents WOULD have produced). G2: when that auto-merge CONFLICTED at this path, the
+    # conflicted tree already carries both sides' text — including a payload taken verbatim
+    # from one side via `-X theirs`/manual resolution — so the auto-merge delta is empty and
+    # misses it. We therefore ALSO measure the hunk against the FIRST parent (the mainline a
+    # reviewer compares against): a payload resolved byte-identical to a non-first parent
+    # still differs from the first parent. Corroborating on EITHER delta closes G2 without
+    # re-flagging benign conflict resolutions (their first-parent hunk is ordinary code, as
+    # the novel-conflict-resolution regression test asserts).
+    first_parent = parent_shas[0]
+    baselines = [base_tree] if base_tree == first_parent else [base_tree, first_parent]
+    # (baseline, introduced-hunk) pairs with a non-empty hunk.
+    pairs = [(b, introduced_added_text(repo, b, merge_sha, path)) for b in baselines]
+    pairs = [(b, d) for b, d in pairs if d.strip()]
+    if not pairs:
+        return False, ""
+
+    # (b) an introduced hunk matches a known worm content signature.
+    if content_sig is not None:
+        for _b, d in pairs:
+            hit = content_sig(d)
+            if hit:
+                return True, f"merge-introduced hunk matches signature: {hit}"
+
+    # (c) context-aware obfuscation of an introduced hunk (G3).
+    if not _is_generated_context(path):
+        # Import here to keep core.git free of a hard security-package dependency.
+        from stayawake.bots.security.obfuscation import analyze_delta
+        for b, d in pairs:
+            verdict = analyze_delta(d, file_at(repo, b, path))
+            if verdict:
+                return True, f"obfuscated merge-introduced hunk: {verdict.reason}"
+    return False, ""
+
+
+def evil_merge_paths(repo: str | Path, merge_sha: str, content_sig=None) -> dict[str, str]:
+    """Paths whose content the merge introduced BEYOND a clean 3-way merge of its parents
+    AND for which that introduction is CORROBORATED as review-evading (see `_corroborated`).
 
     An evil merge smuggles content in the merge commit itself, where a normal PR review —
-    which shows each parent's diff — can't see it. The signal is *not* "differs from both
-    parents": a benign 3-way merge of independent edits to one file also differs from both.
-    The signal is "differs from what merging the parents would have produced". So we compute
-    the parents' clean auto-merged tree and flag only the paths the recorded merge ADDS or
-    MODIFIES relative to it (injected files, or content slipped in during conflict
-    resolution). Pure deletions are NOT flagged: a path the merge *removes* relative to the
-    auto-merge — e.g. resolving by accepting the other branch's deletion of a file one branch
-    had added — introduces no review-evading content, so it is not an evil-merge signal.
+    which shows each parent's diff — can't see it. The raw signal "deviates from the clean
+    auto-merge" is necessary but NOT sufficient: a legitimate conflict resolution picking a
+    valid third variant of a line also deviates. So every deviating path is gated through
+    `_corroborated`, which keeps the finding only when the introduction is structurally
+    review-evading (new file unseen by any parent) or its INTRODUCED hunk is a worm
+    signature or context-aware obfuscation. This dissolves the conflict-resolution false
+    positive while still catching novel obfuscated injection (G3).
 
-    Falls back to the coarser "changed vs every parent" intersection for octopus merges
-    (>2 parents) or when git is too old for `merge-tree --write-tree`.
+    Returns {path: reason}. Pure deletions are NOT flagged (a removed path injects nothing).
+    For octopus merges (>2 parents) or when git is too old for `merge-tree --write-tree`,
+    the candidate set is "added/modified vs the FIRST parent" (mainline tip) — NOT the
+    intersection across every parent. The intersection silently dropped any path
+    byte-identical to one parent, so an octopus payload identical to a non-first parent (G2)
+    produced no finding; the first-parent diff is byte-identity-agnostic and reaches it. The
+    SAME corroboration gate is then applied, so a benign octopus stays clean.
     """
     ps = parents(repo, merge_sha)
     if len(ps) < 2:
-        return set()
+        return {}
+
+    deviating: set[str]
+    base_tree: str | None = None
     if len(ps) == 2:
-        auto = _auto_merge_tree(repo, ps[0], ps[1])
-        if auto is not None:
-            return changed_paths(repo, auto, merge_sha, diff_filter="AM")
-    # Fallback: paths added/modified vs EVERY parent (over-reports overlapping clean merges).
-    common: set[str] | None = None
-    for p in ps:
-        diff = changed_paths(repo, p, merge_sha, diff_filter="AM")
-        common = diff if common is None else (common & diff)
-    return common or set()
+        base_tree = _auto_merge_tree(repo, ps[0], ps[1])
+    if base_tree is not None:
+        deviating = changed_paths(repo, base_tree, merge_sha, diff_filter="AM")
+    else:
+        # Fallback (octopus / pre-2.38 git): we have no synthesized auto-merge tree, so the
+        # FIRST parent (mainline tip) is the baseline a reviewer would compare against. The
+        # candidate set is every path the merge ADDS/MODIFIES relative to that first parent
+        # — i.e. everything the merge brings onto mainline.
+        #
+        # G2: we deliberately do NOT intersect "changed vs EVERY parent" here. That
+        # intersection drops any path whose merge blob is byte-identical to even one parent
+        # (an octopus that pulls a payload-carrying head, or a `-X theirs` resolution to one
+        # side), so such a payload never reached the corroboration gate and produced NO
+        # finding. The first-parent diff is byte-identity-agnostic: a payload identical to a
+        # non-first parent still differs from the first parent and is examined. Topology
+        # cannot separate evil from benign here; the `_corroborated` gate (worm signature /
+        # new-vs-all-parents / context-aware obfuscation of the introduced hunk) does — so a
+        # benign octopus that merely combines clean branches still yields no finding.
+        base_tree = ps[0]
+        deviating = changed_paths(repo, base_tree, merge_sha, diff_filter="AM")
+
+    flagged: dict[str, str] = {}
+    for path in deviating:
+        ok, reason = _corroborated(repo, base_tree, merge_sha, path, ps, content_sig)
+        if ok:
+            flagged[path] = reason
+    return flagged
 
 
 def commit_meta(repo: str | Path, sha: str) -> dict[str, str]:

--- a/tests/bots/security/test_evil_merge.py
+++ b/tests/bots/security/test_evil_merge.py
@@ -62,6 +62,29 @@ class TestEvilMerge(unittest.TestCase):
         self.assertTrue(findings, "evil merge should be detected")
         self.assertIn("evil.txt", findings[0].evidence)
 
+    def test_evil_merge_inside_merged_side_branch_flagged(self):
+        # Regression: an evil merge that lives INSIDE a merged side-branch is reachable only
+        # through a SECOND parent, never the first-parent mainline chain. Enumeration must
+        # traverse ALL merges (`--diff-merges=first-parent` sets only the diff format) — the
+        # earlier `-m --first-parent` restricted *traversal* and silently skipped it.
+        _git(self.d, "checkout", "-qb", "topic")
+        (self.d / "t.txt").write_text("topic\n")
+        _git(self.d, "add", "."); _git(self.d, "commit", "-qm", "topic work")
+        _git(self.d, "checkout", "-qb", "sub")
+        (self.d / "s.txt").write_text("sub\n")
+        _git(self.d, "add", "."); _git(self.d, "commit", "-qm", "sub work")
+        _git(self.d, "checkout", "-q", "topic")
+        _git(self.d, "merge", "--no-ff", "--no-commit", "sub")
+        (self.d / "evil2.txt").write_text("injected only in the side-branch merge\n")
+        _git(self.d, "add", "evil2.txt")
+        _git(self.d, "commit", "-qm", "side-branch merge with injection")
+        # Bring the side branch (with its buried evil merge) onto mainline via a clean merge.
+        _git(self.d, "checkout", "-q", self.base)
+        _git(self.d, "merge", "--no-ff", "-q", "-m", "merge topic into main", "topic")
+        findings = self._findings()
+        self.assertTrue(findings, "evil merge buried inside a merged side-branch must be detected")
+        self.assertIn("evil2.txt", " ".join(f.evidence for f in findings))
+
     def test_overlapping_clean_merge_not_flagged(self):
         # Regression for #1004: both sides edit the SAME file in different hunks; the clean
         # 3-way auto-merge combines them, so the merged file differs from BOTH parents. That
@@ -81,6 +104,49 @@ class TestEvilMerge(unittest.TestCase):
         self.assertEqual(self._findings(), [],
                          "a clean 3-way merge of independent edits must not be flagged")
 
+    def test_obfuscated_injection_into_modified_source_flagged(self):
+        # G3: a NOVEL obfuscated payload (matches no existing signature) MODIFIED into a
+        # tracked, non-sensitive, previously-formatted source file during the merge itself.
+        # The introduced hunk is a charcode-array string shuffler — caught by the
+        # context-aware obfuscation corroborator on the merge-introduced delta.
+        (self.d / "util.js").write_text("export const id = (x) => x;\n")
+        _git(self.d, "add", "util.js"); _git(self.d, "commit", "-qm", "add util")
+        _git(self.d, "checkout", "-qb", "feat2")
+        (self.d / "other.js").write_text("export const k = 1;\n")
+        _git(self.d, "add", "other.js"); _git(self.d, "commit", "-qm", "unrelated feat")
+        _git(self.d, "checkout", "-q", self.base)
+        _git(self.d, "merge", "--no-ff", "--no-commit", "feat2")
+        # Inject obfuscation into util.js within the merge commit (review-evading):
+        with (self.d / "util.js").open("a") as fh:
+            fh.write("var _q=[104,116,116,112,115,58,47,47,120];"
+                     "eval(String.fromCharCode.apply(null,_q));\n")
+        _git(self.d, "add", "util.js"); _git(self.d, "commit", "-qm", "merge feat2")
+        findings = self._findings()
+        self.assertTrue(findings, "obfuscated merge-introduced hunk must be flagged (G3)")
+        self.assertIn("util.js", findings[0].evidence)
+
+    def test_novel_human_conflict_resolution_not_flagged(self):
+        # The FP this whole layer exists to kill: a REAL conflict where the human resolves to
+        # a third, valid, NON-obfuscated variant of the conflicting line. The result deviates
+        # from the clean auto-merge tree (so the raw heuristic flagged it) but the introduced
+        # hunk is ordinary code → no corroboration → must be CLEAN.
+        (self.d / "greet.js").write_text('export const g = () => "hello";\n')
+        _git(self.d, "add", "greet.js"); _git(self.d, "commit", "-qm", "add greet")
+        _git(self.d, "checkout", "-qb", "side2")
+        (self.d / "greet.js").write_text('export const g = () => "hello world";\n')
+        _git(self.d, "add", "greet.js"); _git(self.d, "commit", "-qm", "side greet")
+        _git(self.d, "checkout", "-q", self.base)
+        (self.d / "greet.js").write_text('export const g = () => "hola";\n')
+        _git(self.d, "add", "greet.js"); _git(self.d, "commit", "-qm", "base greet")
+        # conflicting merge (exits 1 on conflict) resolved to a NOVEL third variant:
+        subprocess.run(["git", "-C", str(self.d), "merge", "--no-ff", "--no-commit", "side2"],
+                       capture_output=True, text=True)
+
+        (self.d / "greet.js").write_text('export const g = () => "hello world (es: hola)";\n')
+        _git(self.d, "add", "greet.js"); _git(self.d, "commit", "-qm", "resolve conflict")
+        self.assertEqual(self._findings(), [],
+                         "a benign novel conflict resolution must NOT be flagged")
+
     def test_merge_deleting_one_sided_add_not_flagged(self):
         # Regression for the worm-guard false positive: `feature` ADDS b.txt (absent on base
         # and at the merge-base). A clean 3-way merge KEEPS that addition, so the auto-merge
@@ -92,6 +158,123 @@ class TestEvilMerge(unittest.TestCase):
         _git(self.d, "commit", "-qm", "merge but drop b.txt")
         self.assertEqual(self._findings(), [],
                          "a merge that only deletes a path must not be flagged")
+
+    # ── G2: payload byte-identical to ONE parent escapes the intersection ──────────
+    _CHARCODE = ("var _q=[104,116,116,112,115,58,47,47,120];"
+                 "eval(String.fromCharCode.apply(null,_q));\n")  # obfuscated, no loader sig
+
+    def test_g2_octopus_payload_identical_to_one_parent_flagged(self):
+        # G2: an OCTOPUS merge pulls in three heads. The payload MODIFIES an existing tracked
+        # file (util.js) and the merge resolves it byte-identical to the payload-carrying
+        # parent. The old ">2-parent intersection" (added/modified vs EVERY parent) dropped
+        # util.js — it does NOT differ from the parent that carries it — so NO finding was
+        # ever emitted, even at the merge_commits prefilter (empty combined diff). The
+        # first-parent enumeration + corroboration must now flag it.
+        (self.d / "util.js").write_text("export const id = (x) => x;\n")
+        _git(self.d, "add", "util.js"); _git(self.d, "commit", "-qm", "add util")
+        _git(self.d, "checkout", "-qb", "side")
+        (self.d / "s.txt").write_text("s\n")
+        _git(self.d, "add", "s.txt"); _git(self.d, "commit", "-qm", "side")
+        _git(self.d, "checkout", "-q", self.base)
+        _git(self.d, "checkout", "-qb", "payload")
+        (self.d / "util.js").write_text("export const id = (x) => x;\n" + self._CHARCODE)
+        _git(self.d, "add", "util.js"); _git(self.d, "commit", "-qm", "wip payload")
+        _git(self.d, "checkout", "-q", self.base)
+        # octopus: feature + side + payload; -X theirs resolves util.js to the payload blob,
+        # leaving it byte-identical to the `payload` parent.
+        _git(self.d, "merge", "--no-ff", "-q", "-X", "theirs",
+             "-m", "octopus", "feature", "side", "payload")
+        findings = self._findings()
+        self.assertTrue(findings, "G2 octopus payload identical to one parent must be flagged")
+        self.assertIn("util.js", findings[0].evidence)
+
+    def test_g2_two_parent_resolution_to_one_parent_payload_flagged(self):
+        # G2 in the 2-parent shape: a `-X theirs` merge resolves an existing file to the
+        # feature parent's payload blob verbatim. The combined diff is EMPTY (the merge tree
+        # equals one parent for that path), so the old combined-diff prefilter dropped the
+        # whole merge. The first-parent prefilter keeps it; the auto-merge deviation +
+        # obfuscation corroborator confirm it.
+        (self.d / "util.js").write_text("export const id = (x) => x;\n")
+        _git(self.d, "add", "util.js"); _git(self.d, "commit", "-qm", "add util")
+        _git(self.d, "checkout", "-qb", "evil")
+        (self.d / "util.js").write_text("export const id = (x) => x;\n" + self._CHARCODE)
+        _git(self.d, "add", "util.js"); _git(self.d, "commit", "-qm", "evil edit")
+        _git(self.d, "checkout", "-q", self.base)
+        (self.d / "util.js").write_text("export const id = (y) => y;\n")  # divergent base edit
+        _git(self.d, "add", "util.js"); _git(self.d, "commit", "-qm", "base edit")
+        _git(self.d, "merge", "--no-ff", "-q", "-X", "theirs", "-m", "merge", "evil")
+        findings = self._findings()
+        self.assertTrue(findings, "G2 2-parent -X theirs to payload parent must be flagged")
+        self.assertIn("util.js", findings[0].evidence)
+
+    def test_g2_benign_octopus_not_flagged(self):
+        # The FP guard for the G2 fix: an octopus combining three CLEAN branches (no payload
+        # anywhere). First-parent enumeration surfaces every introduced path, but the
+        # corroboration gate finds no signature/obfuscation and no new-vs-all-parents inject,
+        # so the merge stays clean.
+        for name in ("o1", "o2", "o3"):
+            _git(self.d, "checkout", "-q", self.base)
+            _git(self.d, "checkout", "-qb", name)
+            (self.d / f"{name}.js").write_text(f"export const {name} = 1;\n")
+            _git(self.d, "add", "."); _git(self.d, "commit", "-qm", name)
+        _git(self.d, "checkout", "-q", self.base)
+        _git(self.d, "merge", "--no-ff", "-q", "-m", "octopus", "o1", "o2", "o3")
+        self.assertEqual(self._findings(), [],
+                         "a benign octopus of clean branches must not be flagged")
+
+    # ── G6: ref scope — remote-tracking reachability vs the stash FP ───────────────
+    def test_g6_evil_merge_only_on_remote_tracking_ref_flagged(self):
+        # G6 recall: an evil merge that exists ONLY on a remote-tracking ref the user fetched
+        # (refs/remotes/origin/*) but never merged into a local branch. `--branches --tags`
+        # alone CANNOT reach it (no local branch contains it); `--remotes` must, so the
+        # detector's scope includes it. Build it directly: a merge commit referenced only by
+        # refs/remotes/origin/main, unreachable from HEAD/any local branch.
+        _git(self.d, "merge", "--no-ff", "--no-commit", "feature")
+        (self.d / "evil.txt").write_text("injected in the merge only\n")
+        _git(self.d, "add", "evil.txt")
+        _git(self.d, "commit", "-qm", "remote evil merge")
+        remote_sha = subprocess.run(
+            ["git", "-C", str(self.d), "rev-parse", "HEAD"],
+            capture_output=True, text=True, check=True).stdout.strip()
+        # Park that merge on a remote-tracking ref, then rewind the local branch so NO local
+        # branch reaches it. Only refs/remotes/origin/main now points at the evil merge.
+        _git(self.d, "update-ref", "refs/remotes/origin/main", remote_sha)
+        _git(self.d, "reset", "-q", "--hard", "HEAD~1")
+        # Sanity: unreachable from --branches, reachable from --remotes.
+        from stayawake.core import git as gitutil
+        self.assertNotIn(remote_sha, gitutil.merge_commits(self.d, refs=("--branches",)),
+                         "precondition: evil merge is NOT on any local branch")
+        findings = self._findings()
+        self.assertTrue(findings, "evil merge reachable only via a fetched remote-tracking "
+                                  "ref must be flagged (G6)")
+        self.assertIn("evil.txt", findings[0].evidence)
+
+    def test_g6_stash_merge_never_enumerated(self):
+        # G6 FP guard: a `git stash` creates a 2/3-parent merge commit under refs/stash. The
+        # scope (`--branches --tags --remotes`, deliberately NOT `--all`) must never enumerate
+        # it, so a stash can never become an evil-merge candidate regardless of its content.
+        (self.d / "a.txt").write_text("dirty change\n")   # working-tree dirt to stash
+        _git(self.d, "stash", "-q")
+        from stayawake.core import git as gitutil
+        stash_sha = subprocess.run(
+            ["git", "-C", str(self.d), "rev-parse", "refs/stash"],
+            capture_output=True, text=True, check=True).stdout.strip()
+        self.assertNotIn(stash_sha, gitutil.merge_commits(self.d),
+                         "refs/stash must be outside the merge-enumeration scope")
+        self.assertEqual(self._findings(), [], "a stash must never be an evil-merge finding")
+
+    def test_g6_overlapping_local_and_remote_ref_not_double_counted(self):
+        # G6 cost/dedup: a merge reachable from BOTH a local branch and a remote-tracking ref
+        # must be enumerated exactly once (git log dedups by SHA), so `--remotes` adds no
+        # duplicate-candidate cost in the common case where local and origin agree.
+        _git(self.d, "merge", "--no-ff", "-q", "-m", "honest merge", "feature")
+        head = subprocess.run(["git", "-C", str(self.d), "rev-parse", "HEAD"],
+                              capture_output=True, text=True, check=True).stdout.strip()
+        _git(self.d, "update-ref", "refs/remotes/origin/main", head)  # same SHA on both refs
+        from stayawake.core import git as gitutil
+        cands = gitutil.merge_commits(self.d)
+        self.assertEqual(cands.count(head), 1,
+                         "a merge on both a local and a remote ref must appear once, not twice")
 
 
 if __name__ == "__main__":

--- a/tests/bots/security/test_matchers.py
+++ b/tests/bots/security/test_matchers.py
@@ -18,6 +18,7 @@ EXPECTED_IN_INFECTED = {
     "loader-global-bang", "loader-require-hijack",
     "fake-font-fa-solid-400", "fake-font-text-woff",
     "camouflage-blockchain-readme", "oversized-config-line",
+    "obfuscated-source-file",
     "vscode-task-folderopen-exec", "vscode-task-runs-font",
     "vscode-allow-automatic-tasks", "gitignore-autopush-markers",
 }

--- a/tests/bots/security/test_obfuscation_file.py
+++ b/tests/bots/security/test_obfuscation_file.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""G4 regression: line-AGNOSTIC whole-file obfuscation detection.
+
+A payload SPLIT/WRAPPED across many <2000-char lines, or living in a non-.js
+extension (.jsx/.tsx/.vue/.svelte), defeats the formatting-keyed long-line rule.
+The `obfuscation` matcher / `analyze_file` must still catch it on RAW content, while
+context-scoping keeps vendored/minified/generated paths and legit dense source clean.
+"""
+from __future__ import annotations
+
+import random
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+from stayawake.bots.security.signatures import load_signatures
+from stayawake.bots.security.scanner import scan_target
+from stayawake.bots.security.targets import LocalRepoTarget, ScanOptions
+from stayawake.bots.security.obfuscation import (
+    analyze_file, is_generated_context, _GENERATED_PATH,
+)
+
+SIGS = load_signatures()
+OBF = "obfuscated-source-file"
+
+
+def _scan(files: dict[str, str]) -> set[str]:
+    d = Path(tempfile.mkdtemp())
+    for rel, content in files.items():
+        p = d / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+    t = LocalRepoTarget(d, "t", ScanOptions())
+    return {f.signature_id for f in scan_target(t, SIGS, []).findings}
+
+
+class TestWholeFileObfuscation(unittest.TestCase):
+    # ── True positives: the split-line / non-.js payloads G4 named ──────────────
+    def test_split_charcode_array_in_ts(self):
+        arr = "[" + ",".join(["0x68"] * 40) + "]"
+        wrapped = "\n".join(textwrap.wrap("const d=String.fromCharCode.apply(0," + arr + ");", 60))
+        self.assertIn(OBF, _scan({"x.ts": "const a=1;\n" + wrapped}))
+
+    def test_wrapped_loader_in_jsx(self):
+        packed = "\n".join("var p" + str(i) + "=" + ("z" * 110) + ";" for i in range(40))
+        body = "import React from 'react'\nvar _$_1e42='seed';\n" + packed
+        self.assertIn(OBF, _scan({"C.jsx": body}))
+
+    def test_split_base64_blob_in_vue_without_fingerprint(self):
+        random.seed(1)
+        alph = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+        blob = "".join(random.choice(alph) for _ in range(8000))
+        chunks = "\n".join(blob[i:i + 150] for i in range(0, len(blob), 150))
+        self.assertIn(OBF, _scan({"App.vue": "<script>\nconst x=`\n" + chunks + "\n`\n</script>"}))
+
+    def test_eval_atob_in_svelte(self):
+        body = "<script>\n" + "const y=" + ("q" * 450) + ";\n" * 6 + "eval(atob(y));\n</script>"
+        self.assertIn(OBF, _scan({"P.svelte": body}))
+
+    def test_loader_line_just_under_long_line_threshold(self):
+        # <2000 chars on every line, so the formatting-keyed rule never fires.
+        line = "export default {plugins:[" + "0," * 900 + "]};var _$_ab='x';function sfL(w){return w}"
+        self.assertLess(max(len(l) for l in line.splitlines()), 2000)
+        self.assertIn(OBF, _scan({"postcss.config.mjs": line}))
+
+    # ── False positives: legit dense source / vendored context stays clean ──────
+    def test_normal_big_component_clean(self):
+        body = "import React from 'react';\n" + "\n".join(
+            f"export function C{i}(p){{return <div className='w-{i}'>Hi {{p.n}} item {i} ok</div>;}}"
+            for i in range(200))
+        self.assertNotIn(OBF, _scan({"Big.jsx": body}))
+
+    def test_long_prose_template_constant_clean(self):
+        words = " ".join(["the quick brown fox jumps over the lazy dog"] * 300)
+        self.assertNotIn(OBF, _scan({"text.js": "export const T = `" + words + "`;\n"}))
+
+    def test_inlined_data_uri_asset_clean(self):
+        uri = "export const logo='data:image/png;base64," + ("AB" * 400) + "';\n"
+        self.assertNotIn(OBF, _scan({"assets.ts": uri}))
+
+    def test_low_entropy_long_array_clean(self):
+        self.assertNotIn(OBF, _scan({"postcss.config.mjs": "export default {p:[" + "0," * 900 + "]};\n"}))
+
+    def test_vendored_and_generated_paths_suppressed(self):
+        arr = "var a=[" + ",".join(["0x68"] * 40) + "];String.fromCharCode(127)"
+        for path in ("lib/app.min.js", ".pnp.cjs", ".yarn/releases/yarn.cjs",
+                     "dist/main.js", "src/gql.generated.ts", "proto/__generated__/x.pb.js"):
+            self.assertNotIn(OBF, _scan({path: arr}), f"{path} should be suppressed (generated context)")
+
+    # ── The shared context predicate (regression for the mid-path anchor bug) ───
+    def test_generated_context_matches_mid_path_filename_tokens(self):
+        for p in ("src/gql.generated.ts", "a/app.min.js", "x/y.pb.js", "z/q.graphql.ts", "out/b.map"):
+            self.assertTrue(is_generated_context(p), p)
+        for p in ("src/index.ts", "postcss.config.mjs", "components/App.jsx"):
+            self.assertFalse(is_generated_context(p), p)
+
+    # ── analyze_file is line-agnostic (no single long line needed) ──────────────
+    def test_analyze_file_catches_wrapped_exec_sink(self):
+        self.assertTrue(analyze_file("const a=1\neval(\n  atob('x')\n)\n", ".js"))
+
+    def test_analyze_file_clean_on_ordinary_code(self):
+        code = "function add(a, b) {\n    return a + b;\n}\nexport default add;\n"
+        self.assertFalse(analyze_file(code, ".js"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1052.

## Problem

Two heuristic rules flipped verifiably-clean repos to `INFECTED`:
- **evil-merge** fired on `git stash` commits and ordinary conflict/PR merges — it flagged *any* deviation from the clean auto-merge tree, with no maliciousness check.
- **oversized-config-line** fired on committed minified vendor bundles (`.yarn/releases/*.cjs`, `.pnp.cjs`, `*.min.js`) on raw line length alone.

## Approach — context-aware confidence

A raw signal (long line, merge blob-deviation) is **suppressed where obfuscation is expected** (vendored/minified/generated paths, via a single shared `is_generated_context` predicate) and **decisive only where it's anomalous** (hand-authored source/config, or merge-introduced hunks). This clears the false positives *and* closes the recall gaps, instead of trading one for the other.

### evil-merge (`core/git.py`, `matchers/git_history.py`)
- Enumerate merges over `--branches --tags --remotes` (not `--all` → never walks `refs/stash`), using **`--diff-merges=first-parent`** so traversal still reaches an evil merge buried inside a merged side-branch, and a payload byte-identical to one parent (G1/G2).
- Flag an introduced path only if it's **new-vs-all-parents**, matches a **loader signature**, or its **introduced hunk is obfuscated** vs the file's baseline (G3) — dissolving the conflict-resolution / `-X theirs` / lockfile-remerge FPs.

### obfuscation (new `obfuscation.py` + `ObfuscationMatcher`; `heuristic.py`)
- A **line-agnostic** whole-file detector over raw content for hand-authored extensions — catches split/wrapped payloads and `.jsx/.tsx/.vue/.svelte` (G4).
- `oversized-config-line` now requires loader-fingerprint or context-obfuscation corroboration (G5).

### Verdict left unchanged (on purpose)
`infected = bool(findings)` is **not** changed. Matchers now emit only *corroborated* findings, so a severity threshold is unnecessary — and gating on `≥HIGH` would have wrongly cleared the **medium real IOCs** (`gitignore-autopush-markers`, `camouflage-blockchain-readme`).

## Review note

This was reviewed before merge; the review caught and fixed a **traversal regression** (`-m --first-parent` restricts history traversal, so an evil merge inside a merged side-branch was silently skipped). Fixed via `--diff-merges=first-parent` and pinned by a new regression test. Also consolidated a duplicated `build_content_sig` helper into `matchers/base.py`.

## Verification

- **Clean** Yarn-Berry SPA (yarn binary + `.pnp.cjs` + 3 git stashes + clean merge) → `0 findings`, exit 0.
- **Infected** stays infected: postcss appended-payload fixture, a wrapped `.jsx` payload (G4), the medium `gitignore-autopush-markers` IOC, and an evil merge buried in a merged side-branch.
- Full suite: **150 passing** (`python -m unittest discover -s tests`).