### PR TITLE
fix(security): durable exec-via-constructor detection for the #1053 loader family

### DIFF
--- a/src/stayawake/bots/security/obfuscation.py
+++ b/src/stayawake/bots/security/obfuscation.py
@@ -18,8 +18,11 @@ we require either a *self-evidently executable* obfuscation construct OR a
   * charcode / hex numeric arrays  — `[104,116,116,112,...]`, `[0x68,0x74,...]`
     feeding String.fromCharCode / apply: the canonical Shai-Hulud string shuffler
     and the generic "build a string from numbers so no literal is greppable" trick.
-  * dynamic-exec sinks            — eval(, new Function(, atob(, Function(, the
-    require-hijack global['!']: code that turns decoded bytes back into execution.
+  * dynamic-exec sinks            — eval(, new Function(, atob(, fromCharCode, the
+    require-hijack global['!'], and reflective `x['constructor'](…)` Function-
+    constructor smuggling (name-agnostic catch for a renamed decoder, #1053; the
+    `new …` clone idiom is carved out): code that turns decoded bytes back into
+    execution.
   * long base64 blob              — a single >=120-char [A-Za-z0-9+/=] run that is
     not already plain text (most real code has spaces/punctuation breaking it up).
   * minification spike            — the introduced text is one (or few) very long
@@ -49,6 +52,41 @@ _EXEC_SINK = re.compile(
     r"String\s*[.\[]\s*[\"']?fromCharCode|global\s*\[\s*['\"]!['\"]\s*\]\s*=",
     re.IGNORECASE,
 )
+# Reflective Function-constructor smuggling: `x['constructor'](decoded)` reaches the
+# Function constructor through a bracket-string key, name-agnostically — so the worm's
+# exec step (#1053) survives renaming the literal `sfL`/`_$_`/`global['!']` fingerprints.
+# This is a DEFENSE-IN-DEPTH catch of the lazy variant, not a full closure: the same
+# capability is reachable by a computed key `(function(){})[k](code)`, the dot form
+# `[].constructor.constructor(code)`, `require('vm').runInThisContext`, or bare
+# `Function(code)()` — none of which any token blacklist can durably cover. The real
+# durable lever is the Tier-2 density anomaly, tracked separately.
+#
+# Gated apart from _EXEC_SINK (see _has_exec_sink) so we can carve out the one broad
+# benign collision: the polymorphic same-type clone `new <expr>['constructor'](...)`
+# used by value objects / ORM entities / immutable records (and their tests). The worm
+# NEVER prefixes with `new` (it calls the smuggled Function as a plain function on a
+# decoded variable), so excluding a `new`-prefixed reflective constructor drops that
+# false positive with zero loss of the catch. Plain `obj['constructor'].name` access
+# (no call) never matches — the arm requires `]` immediately followed by `(`.
+_CONSTRUCTOR_EXEC = re.compile(r"\[\s*[\"']constructor[\"']\s*\]\s*\(")
+# `new <ident/member-chain>` immediately before the bracket. The tight `[\w$.)\]]` class
+# (no space/comma/`(`) means only a direct `new a.b['constructor'](` is excluded; a
+# comma/whitespace splice like `new Date(), x['constructor'](p)` still flags.
+_NEW_CLONE_PREFIX = re.compile(r"\bnew\s+[\w$.)\]]*\s*$")
+
+
+def _has_exec_sink(s: str) -> bool:
+    """True if `s` contains a dynamic-execution sink: any literal _EXEC_SINK construct,
+    or a reflective `['constructor'](` call that is NOT a `new <expr>['constructor'](...)`
+    polymorphic clone (the benign idiom the worm never uses). Every constructor-call
+    occurrence is checked, so a `new`-clone earlier in the text can't mask a real sink
+    later."""
+    if _EXEC_SINK.search(s):
+        return True
+    return any(
+        not _NEW_CLONE_PREFIX.search(s[max(0, m.start() - 48):m.start()])
+        for m in _CONSTRUCTOR_EXEC.finditer(s)
+    )
 # A long unbroken base64-ish run not already broken up by code/prose punctuation.
 _B64_BLOB = re.compile(r"[A-Za-z0-9+/]{120,}={0,2}")
 # A self-describing inline asset (image/font/media data-URI). A base64 blob that is the
@@ -201,8 +239,10 @@ def analyze_file(text: str, ext: str = "") -> ObfuscationVerdict:
     flat = body.replace("\n", "").replace("\r", "")
     if _NUM_ARRAY.search(flat):
         return ObfuscationVerdict(True, "charcode/byte numeric-array literal (string shuffler)")
-    if _EXEC_SINK.search(body):
-        return ObfuscationVerdict(True, "dynamic-exec sink (eval/Function/atob/fromCharCode)")
+    # Search the raw body AND the newline-flattened form so an exec sink wrapped
+    # across line breaks (`sfL['constructor']\n(decoded)`) is still seen.
+    if _has_exec_sink(body) or _has_exec_sink(flat):
+        return ObfuscationVerdict(True, "dynamic-exec sink (eval/Function/atob/fromCharCode/constructor)")
     deassetted = _DATA_URI.sub("", flat)
     if _has_b64_payload(deassetted):
         return ObfuscationVerdict(True, "long unbroken base64 blob")
@@ -265,8 +305,8 @@ def analyze_delta(introduced: str, baseline: str = "") -> ObfuscationVerdict:
     # 1) Self-evidently executable obfuscation constructs — sufficient on their own.
     if _NUM_ARRAY.search(text):
         return ObfuscationVerdict(True, "charcode/byte numeric-array literal (string shuffler)")
-    if _EXEC_SINK.search(text):
-        return ObfuscationVerdict(True, "dynamic-exec sink (eval/Function/atob/fromCharCode)")
+    if _has_exec_sink(text):
+        return ObfuscationVerdict(True, "dynamic-exec sink (eval/Function/atob/fromCharCode/constructor)")
     # Strip self-describing inline assets (image/font data-URIs) before the base64 test:
     # a `data:...;base64,...` payload is a legitimate inlined asset, not packed code.
     deassetted = _DATA_URI.sub("", text)

--- a/tests/bots/security/test_obfuscation_file.py
+++ b/tests/bots/security/test_obfuscation_file.py
@@ -64,6 +64,29 @@ class TestWholeFileObfuscation(unittest.TestCase):
         self.assertLess(max(len(l) for l in line.splitlines()), 2000)
         self.assertIn(OBF, _scan({"postcss.config.mjs": line}))
 
+    def test_mutated_loader_caught_via_constructor_exec(self):
+        # #1053 durability: a re-obfuscated variant renames EVERY literal fingerprint
+        # (no _$_, no sfL, no global['!'], no fromCharCode, no numeric array) and keeps
+        # every line short + low-density, so neither a loader content signature nor the
+        # packed/entropy heuristic can fire. The ONLY thing left to catch it is the
+        # structural exec-via-constructor sink — the name-agnostic Function-constructor
+        # smuggling (`dec['constructor'](...)`) the worm family cannot rename away.
+        variant = "\n".join([
+            "const cfg = { plugins: ['@tailwindcss/postcss'] };",
+            "export default cfg;",
+            "const seed = 'inert';",
+            "const dec = function (w) { return w; };",
+            "const run = dec['constructor']('return 1');",
+            "run();",
+        ])
+        self.assertLess(max(len(l) for l in variant.splitlines()), 400)
+        self.assertIn(OBF, _scan({"postcss.config.mjs": variant}))
+
+    def test_wrapped_constructor_exec_caught(self):
+        # The exec sink wrapped across a line break is still caught.
+        self.assertTrue(
+            analyze_file("var q=function(){};\nq['constructor']\n('return 3')();\n", ".js"))
+
     # ── False positives: legit dense source / vendored context stays clean ──────
     def test_normal_big_component_clean(self):
         body = "import React from 'react';\n" + "\n".join(
@@ -82,6 +105,35 @@ class TestWholeFileObfuscation(unittest.TestCase):
     def test_low_entropy_long_array_clean(self):
         self.assertNotIn(OBF, _scan({"postcss.config.mjs": "export default {p:[" + "0," * 900 + "]};\n"}))
 
+    def test_constructor_member_access_without_call_is_clean(self):
+        # Plain ['constructor'] access (no call) is ordinary reflection — the exec-sink
+        # arm requires the bracket-string *call* form (`]` then `(`), so `.name` access
+        # must NOT trip it. Guards the false-positive boundary of the #1053 change.
+        code = "const n = obj['constructor'].name;\nexport default n;\n"
+        self.assertNotIn(OBF, _scan({"util.ts": code}))
+        self.assertFalse(analyze_file(code, ".ts"))
+
+    def test_polymorphic_clone_new_constructor_is_clean(self):
+        # FP carve-out: `new <expr>['constructor'](...)` is the same-type clone idiom
+        # (value objects / ORM entities / immutable records and their tests). The worm
+        # never prefixes its exec with `new`, so this benign family must stay clean even
+        # though it contains the bracket-string constructor call.
+        for code in (
+            "export class Shape{constructor(p){this.p=p}\n"
+            "  clone(){return new this['constructor'](this.p)}}\n",
+            "export function clone(o){return new o['constructor'](o)}\n",
+            "const copy = new doc['constructor'](doc.toObject());\nexport default copy;\n",
+        ):
+            self.assertNotIn(OBF, _scan({"model.ts": code}), code)
+            self.assertFalse(analyze_file(code, ".ts"), code)
+
+    def test_constructor_exec_without_new_still_flagged(self):
+        # The carve-out is ONLY for a directly `new`-prefixed reflective constructor.
+        # A plain (non-new) call, and a comma/whitespace splice that tries to borrow a
+        # nearby `new`, must still flag (the worm's actual exec shape).
+        self.assertTrue(analyze_file("var f=q['constructor']('return 1');\n", ".js"))
+        self.assertTrue(analyze_file("new Date(), x['constructor'](decoded);\n", ".js"))
+
     def test_vendored_and_generated_paths_suppressed(self):
         arr = "var a=[" + ",".join(["0x68"] * 40) + "];String.fromCharCode(127)"
         for path in ("lib/app.min.js", ".pnp.cjs", ".yarn/releases/yarn.cjs",
@@ -98,6 +150,10 @@ class TestWholeFileObfuscation(unittest.TestCase):
     # ── analyze_file is line-agnostic (no single long line needed) ──────────────
     def test_analyze_file_catches_wrapped_exec_sink(self):
         self.assertTrue(analyze_file("const a=1\neval(\n  atob('x')\n)\n", ".js"))
+
+    def test_analyze_file_catches_constructor_exec_sink(self):
+        # Renamed decoder reaching the Function constructor via X['constructor'](...).
+        self.assertTrue(analyze_file("var q=function(){};q['constructor']('return 2')();\n", ".js"))
 
     def test_analyze_file_clean_on_ordinary_code(self):
         code = "function add(a, b) {\n    return a + b;\n}\nexport default add;\n"


### PR DESCRIPTION
## What & why

Detection-durability hardening from the **#1053 true-positive** case study (the obfuscated code-loader caught in a Next.js `postcss.config.mjs`).

The five `loader-*` content signatures each anchor on a **per-sample-mutable token** — the decoder name `sfL`, the `_$_` id, the `global['!']` key, the `fromCharCode(127)` separator — so a re-obfuscated variant of the same worm can evade **all** of them (the issue's own warning: _"signature on structure, not literals"_). This adds a **name-agnostic structural catch** for the family's exec step — reflective Function-constructor smuggling `x['constructor'](decoded)` — to the **context-scoped** obfuscation layer (`analyze_file` / `analyze_delta`), so a renamed-decoder variant is still flagged via `obfuscated-source-file`.

The 5 precise `loader-*` signatures are **kept untouched** (they're low-FP and correct on the real sample); durability is *added alongside*, not swapped in.

## False-positive safety (the #1052 lesson)

An adversarial FP hunt found one broad benign collision: the polymorphic same-type clone idiom `new <expr>['constructor'](...)` (value objects / ORM entities / immutable records and their tests). Since the worm **never** prefixes its exec with `new`, a verified `new`-prefix carve-out drops that false positive with **zero** loss of the catch. Plain `['constructor'].name` access (no call) never matched. The arm is **medium severity** and only runs on authored extensions in **non-generated** paths.

## Scope — honest boundary

This is **defense-in-depth against the lazy renamed-decoder variant, not a full closure.** An adversarial evasion pass confirmed the exec *capability* remains reachable via a computed-key Function (`(function(){})[k](code)`), the dot form (`[].constructor.constructor`), `require('vm')`, or bare `Function(code)()`, combined with sub-400-char line wrapping + chunked `Buffer.from(…,'base64')` decode. The real load-bearing hole is **Tier-2's `longest < 400` early-return**, untouched here — its durable fix (drop the early-return + treat chunked-concat base64 as a blob) rebalances the exact gates that keep #1052 FP-free, so it's tracked as a **follow-up** needing its own brainstorm + FP-verification pass.

## Tests

+6 regressions: mutated-variant catch (proven to evade every pre-change signal), wrapped-exec, the clone carve-out + access FP guards, and "non-`new` constructor exec still flags". Full suite **156 pass**; #1053 fixture still INFECTED, clean fixture still clean.

Refs #1053.