### PR TITLE
fix(security): Tier-2 hardening — reassemble concat/array-chunked + escape-encoded payloads (#1053)

### DIFF
--- a/src/stayawake/bots/security/obfuscation.py
+++ b/src/stayawake/bots/security/obfuscation.py
@@ -25,6 +25,12 @@ we require either a *self-evidently executable* obfuscation construct OR a
     execution.
   * long base64 blob              — a single >=120-char [A-Za-z0-9+/=] run that is
     not already plain text (most real code has spaces/punctuation breaking it up).
+  * concat/escape-encoded blob    — the SAME payload split into quoted chunks
+    (`"a"+"b"+…` or `["a","b"].join("")`) or written as a dense byte-range, high-
+    entropy `\\xNN`/`\\uNNNN` escape run; caught by normalizing the reassembly seams
+    away and re-testing the reassembled content (#1053). Residual boundaries:
+    template-literal `${a}${b}` reassembly (chunks live in variables) and `.concat`
+    via non-quote args are not statically reassembled.
   * minification spike            — the introduced text is one (or few) very long
     lines AND the file's baseline was normally-formatted (short lines): a
     previously hand-formatted file does not legitimately gain a 2 KB single line
@@ -100,6 +106,86 @@ _DATA_URI = re.compile(r"data:[\w.+-]+/[\w.+-]+;base64,[A-Za-z0-9+/]+={0,2}", re
 # encoded payload and must not trip the blob trigger. This gate closes the long-URL FP
 # (G5) without weakening detection of genuine base64 (which clears it by a wide margin).
 _B64_BLOB_MIN_ENTROPY = 4.5
+
+# ── Wrap/concat-resistant payload-at-rest detection (#1053 Tier-2 hardening) ──────
+# The blob/array detectors above key on a long UNBROKEN run, which an attacker defeats
+# two ways without changing the payload: (A) splitting it into short quoted chunks joined
+# by `+` (`"aaa" + "bbb"`), whose quote/plus/space seams break the run; and (B) encoding it
+# as a dense run of \xNN/\uNNNN escapes decoded at runtime (Buffer.from / fromCodePoint),
+# which carries no [A-Za-z0-9+/] run at all. Both are reversible by NORMALIZING the seams
+# away, then re-testing the reassembled content — what these two helpers add. Escape runs
+# are tested on the de-chunked form too, so a chunked escape payload is reassembled first.
+
+# A JS string-reassembly seam: a closing quote, a `+` (concat) OR `,` (array element /
+# .concat arg) separator, an opening quote — any whitespace/newlines between. Collapsing it
+# rejoins `"aaa" + "bbb"` AND `["aaa","bbb"].join("")` (the canonical obfuscator string-
+# array primitive) into one run. Only quote-SEP-quote seams match, so base64 `+` inside a
+# chunk, arithmetic `a + b`, a `["x", host]` array with a variable, and a list separator
+# in prose are all untouched. The downstream >=120-char + 4.5-bit blob gate is what keeps
+# this false-positive-safe: reassembling a legit short/low-entropy array trips nothing.
+_CONCAT_SEAM = re.compile(r"['\"]\s*[,+]\s*['\"]")
+
+# A contiguous run of >= _MIN_ESCAPE_RUN numeric escapes (hex byte, BMP unicode, unicode
+# code-point, or 3-digit octal). Length alone is NOT decisive (a 12-emoji row is 24 \uXXXX
+# surrogate escapes; a crypto/magic-byte fixture is a short \xNN run), so _escape_run also
+# applies a decoded byte-range + entropy gate — see there. 48 is the floor: above a
+# 12-emoji row and a 32-byte KAT vector, far below any real escape-encoded loader (hundreds
+# to thousands of bytes).
+_MIN_ESCAPE_RUN = 48
+_ESCAPE_RUN = re.compile(
+    r"(?:\\x[0-9a-fA-F]{2}|\\u[0-9a-fA-F]{4}|\\u\{[0-9a-fA-F]{1,6}\}|\\[0-3][0-7]{2})"
+    r"{%d,}" % _MIN_ESCAPE_RUN
+)
+# Single-escape capture (one alternative group populated per match) for decoding a run.
+_ESCAPE_TOKEN = re.compile(
+    r"\\x([0-9a-fA-F]{2})|\\u\{([0-9a-fA-F]{1,6})\}|\\u([0-9a-fA-F]{4})|\\([0-3][0-7]{2})")
+# A real escape-encoded payload decodes to BYTES (0-255) with high entropy. Benign runs
+# that clear the length bar do not: emoji/CJK/combining-mark tables decode to codepoints
+# >255 in a narrow Unicode block, and structured magic-byte/file headers are low-entropy.
+_ESCAPE_BYTE_FRAC = 0.8        # >=80% of decoded values must be in byte range (<=255)
+_ESCAPE_MIN_ENTROPY = 4.5      # decoded-value entropy, mirroring the base64-blob gate
+
+
+def _dechunk(s: str) -> str:
+    """Collapse JS string-reassembly seams so a payload split into quoted chunks
+    (`"aaa" + "bbb"` OR `["aaa","bbb"].join("")`) is rejoined into one run before the
+    blob/escape detectors see it. Cheap; a no-op on text with no quote-SEP-quote seams."""
+    return _CONCAT_SEAM.sub("", s)
+
+
+def _decode_escapes(run: str) -> list[int]:
+    """Decode an escape run to its numeric values (hex byte, code-point, BMP unit, octal)."""
+    out: list[int] = []
+    for hx, ucp, u4, oc in _ESCAPE_TOKEN.findall(run):
+        if hx:
+            out.append(int(hx, 16))
+        elif ucp:
+            out.append(int(ucp, 16))
+        elif u4:
+            out.append(int(u4, 16))
+        elif oc:
+            out.append(int(oc, 8))
+    return out
+
+
+def _escape_run(s: str) -> bool:
+    """True if `s` carries a contiguous run of >= _MIN_ESCAPE_RUN numeric escapes that
+    decode to a high-entropy BYTE payload. The byte-range + entropy gate separates a packed
+    worm payload (0-255 bytes, high entropy) from benign runs that merely clear the length
+    bar: emoji/CJK/combining-mark tables (codepoints >255, narrow blocks) and structured
+    magic-byte/file-header fixtures (low entropy). Every run is checked, so a benign run
+    earlier in the file cannot mask a real payload later. Residual (documented): a >=48-byte
+    high-entropy crypto KAT vector written as \\xNN is byte-range + high-entropy and stays a
+    (rare, medium-severity, human-triageable) finding."""
+    for m in _ESCAPE_RUN.finditer(s):
+        vals = _decode_escapes(m.group(0))
+        if not vals:
+            continue
+        byte_frac = sum(1 for v in vals if v <= 0xFF) / len(vals)
+        if byte_frac >= _ESCAPE_BYTE_FRAC and _shannon("".join(map(chr, vals))) >= _ESCAPE_MIN_ENTROPY:
+            return True
+    return False
+
 
 # Minification: a single introduced line at/above this length in a file whose
 # baseline lines were comfortably shorter. Kept well under the 2000-char long-line
@@ -220,7 +306,8 @@ def analyze_file(text: str, ext: str = "") -> ObfuscationVerdict:
 
     Two tiers, mirroring analyze_delta:
       1) self-evidently executable obfuscation (charcode/byte array, dynamic-exec sink,
-         long unbroken base64 blob) — sufficient on its own, line-independent.
+         long base64 blob — including one reassembled from concat-chunked chunks or a
+         dense escape-encoded run) — sufficient on its own, line-independent.
       2) a corroborated whole-file minification+entropy anomaly: the file carries an
          outlier-long line AND a dense packed region that dominates it AND the whole
          file reads as high-entropy. This is the in-file analogue of analyze_delta's
@@ -246,6 +333,14 @@ def analyze_file(text: str, ext: str = "") -> ObfuscationVerdict:
     deassetted = _DATA_URI.sub("", flat)
     if _has_b64_payload(deassetted):
         return ObfuscationVerdict(True, "long unbroken base64 blob")
+    # A+B (#1053): reassemble concat-chunked payloads, then re-test for a base64 blob or a
+    # dense escape-encoded byte run — both survive the attacker splitting/encoding the
+    # payload to dodge the unbroken-run detectors above (the merged-PR Tier-2 hardening).
+    dechunked = _dechunk(deassetted)
+    if _has_b64_payload(dechunked):
+        return ObfuscationVerdict(True, "reassembled chunked base64 blob (string-concat splitting)")
+    if _escape_run(dechunked):
+        return ObfuscationVerdict(True, "dense escape-encoded byte payload (\\xNN/\\uNNNN run)")
 
     # Tier 2 — corroborated whole-file minification anomaly (the split-line payload, and
     # G5: a loader-EVADED single long line in a real config file — packed/encoded content

--- a/tests/bots/security/test_obfuscation_file.py
+++ b/tests/bots/security/test_obfuscation_file.py
@@ -87,6 +87,48 @@ class TestWholeFileObfuscation(unittest.TestCase):
         self.assertTrue(
             analyze_file("var q=function(){};\nq['constructor']\n('return 3')();\n", ".js"))
 
+    def test_chunked_base64_blob_reassembled(self):
+        # #1053 Tier-2 (signal A): a base64 payload split into short quoted chunks joined
+        # by `+` and WRAPPED to <400-char lines dodges the long-line + unbroken-run blob
+        # detectors. De-chunking the concat seams reassembles the blob and catches it.
+        random.seed(11)
+        alph = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+        blob = "".join(random.choice(alph) for _ in range(900))
+        chunks = " +\n  ".join('"%s"' % blob[i:i + 60] for i in range(0, len(blob), 60))
+        src = "const cfg = {};\nexport default cfg;\nconst b =\n  " + chunks + ";\n"
+        self.assertLess(max(len(l) for l in src.splitlines()), 400)  # evades old Tier-2
+        self.assertIn(OBF, _scan({"postcss.config.mjs": src}))
+
+    def test_escape_encoded_payload_flagged(self):
+        # #1053 Tier-2 (signal B): a payload written as a dense run of \xNN escapes carries
+        # no base64/charcode-array tell, but a long contiguous run of high-entropy BYTE
+        # escapes is an encoded blob. 64 bytes spread over 0-255 clears the 48-run length
+        # bar AND the byte-range + entropy gate.
+        esc = "".join("\\x%02x" % ((i * 7 + 3) % 256) for i in range(64))
+        src = 'const s = "' + esc + '";\nexport default s;\n'
+        self.assertLess(max(len(l) for l in src.splitlines()), 400)
+        self.assertIn(OBF, _scan({"x.js": src}))
+
+    def test_chunked_escape_payload_reassembled(self):
+        # A+B together: escapes split across concat chunks must be reassembled past the
+        # 48-run threshold before the byte/entropy gate sees them.
+        a = "".join("\\x%02x" % ((i * 5 + 1) % 256) for i in range(30))
+        b = "".join("\\x%02x" % ((i * 5 + 1) % 256) for i in range(30, 64))
+        src = 'const s = "' + a + '" +\n  "' + b + '";\nexport default s;\n'
+        self.assertIn(OBF, _scan({"x.mjs": src}))
+
+    def test_join_array_reassembly_caught(self):
+        # Signal A, the canonical obfuscator primitive: a base64 payload stored as a string
+        # ARRAY rejoined with .join("") — comma-quote seams, not `+`. _dechunk must collapse
+        # those too, else the most common off-the-shelf obfuscator output walks straight past.
+        random.seed(13)
+        alph = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+        blob = "".join(random.choice(alph) for _ in range(900))
+        arr = ",\n  ".join('"%s"' % blob[i:i + 50] for i in range(0, len(blob), 50))
+        src = "const p = [\n  " + arr + "\n].join('');\nexport default p;\n"
+        self.assertLess(max(len(l) for l in src.splitlines()), 400)
+        self.assertIn(OBF, _scan({"x.mjs": src}))
+
     # ── False positives: legit dense source / vendored context stays clean ──────
     def test_normal_big_component_clean(self):
         body = "import React from 'react';\n" + "\n".join(
@@ -104,6 +146,57 @@ class TestWholeFileObfuscation(unittest.TestCase):
 
     def test_low_entropy_long_array_clean(self):
         self.assertNotIn(OBF, _scan({"postcss.config.mjs": "export default {p:[" + "0," * 900 + "]};\n"}))
+
+    def test_short_literal_concat_clean(self):
+        # A's de-chunk must not manufacture a blob from ordinary short string concatenation
+        # — `"foo" + "bar"` reassembles to a short, low-entropy run that misses the blob gate.
+        code = ("export const url = 'https://' + 'api.' + 'example' + '.com' + '/v1';\n"
+                "export const msg = 'hello, ' + 'world' + '!';\n")
+        self.assertNotIn(OBF, _scan({"config.ts": code}))
+        self.assertFalse(analyze_file(code, ".ts"))
+
+    def test_few_escapes_clean(self):
+        # B requires a long contiguous escape RUN; a regex character class or a couple of
+        # unicode escapes (handfuls, not a payload) must stay clean.
+        code = ("export const re = /[\\x00-\\x1f\\u2028\\u2029]/g;\n"
+                "export const bullet = '\\u2022 item';\n")
+        self.assertNotIn(OBF, _scan({"util.js": code}))
+        self.assertFalse(analyze_file(code, ".js"))
+
+    def test_emoji_surrogate_escape_run_clean(self):
+        # FP guard (signal B): emoji written as \uXXXX surrogate pairs decode to codepoints
+        # >255 clustered in a narrow block — long enough to clear 48, but the byte-range gate
+        # keeps it clean. ASCII-only-source lint rules push devs toward exactly this form.
+        emoji = "".join("\\u%04x\\u%04x" % (0xD83D, 0xDE00 + (i % 60)) for i in range(40))
+        code = 'export const SMILEYS = "' + emoji + '";\n'
+        self.assertNotIn(OBF, _scan({"emojiData.ts": code}))
+        self.assertFalse(analyze_file(code, ".ts"))
+
+    def test_magic_byte_fixture_clean(self):
+        # FP guard (signal B): a structured file-header/magic-byte test fixture is short and
+        # low-entropy — below the 48-run bar and the entropy gate.
+        png = "\\x89\\x50\\x4e\\x47\\x0d\\x0a\\x1a\\x0a\\x49\\x48\\x44\\x52\\x00\\x00\\x00\\x10"
+        code = 'export const PNG_HEADER = Buffer.from("' + png + '", "binary");\n'
+        self.assertNotIn(OBF, _scan({"sniffer.test.js": code}))
+        self.assertFalse(analyze_file(code, ".js"))
+
+    def test_combining_marks_escape_run_clean(self):
+        # FP guard (signal B): a combining-diacritical block (U+0300..U+036F) is a contiguous
+        # \u run but a narrow >255 codepoint block — byte-range gate keeps it clean.
+        marks = "".join("\\u%04x" % (0x0300 + (i % 0x70)) for i in range(60))
+        code = 'export const COMBINING = "' + marks + '";\n'
+        self.assertNotIn(OBF, _scan({"normalize.test.ts": code}))
+        self.assertFalse(analyze_file(code, ".ts"))
+
+    def test_legit_string_array_clean(self):
+        # FP guard (signal A): de-chunking comma seams must not manufacture a blob from an
+        # ordinary string array — low-entropy words, and SRI/hex lists whose -/=/# separators
+        # break the base64 run, both reassemble to nothing that clears the 120/4.5 gate.
+        words = "export const C = [" + ",".join("'%s'" % w for w in
+                 ["apple", "banana", "cherry", "date", "fig", "grape"] * 30) + "];\n"
+        sri = "export const H = [" + ",".join("'sha384-%s'" % ("AbC9+/" * 14) for _ in range(8)) + "];\n"
+        self.assertNotIn(OBF, _scan({"data.ts": words}))
+        self.assertNotIn(OBF, _scan({"sri.ts": sri}))
 
     def test_constructor_member_access_without_call_is_clean(self):
         # Plain ['constructor'] access (no call) is ordinary reflection — the exec-sink


### PR DESCRIPTION
## What & why

Closes the **durable evasion** left open after the exec-via-constructor catch (#1060). A self-decoding worm that wraps every line < 400 chars and either splits its blob into quoted chunks (`"a"+"b"` or `["a","b"].join("")`) or encodes it as a dense escape run slipped **every** prior detector — the long-line gate, the unbroken-run base64/charcode detectors, and the packed-shape Tier-2 gates. Two **wrap/concat-resistant** signals close it by *normalizing the reassembly seams away*, then re-testing the reassembled content:

- **A — de-chunk + re-test.** `_dechunk` collapses string-reassembly seams: `"a" + "b"` **and** `["a","b"].join("")` (the canonical obfuscator string-array primitive), then re-runs the base64-blob detector. FP-safe via the existing **≥120-char + 4.5-bit entropy** blob gate, so a legit short/low-entropy array (words, SRI/UUID/hex lists whose `-`/`=`/`#` break the run) reassembles to nothing.
- **B — gated escape run.** `_escape_run` flags a contiguous run of **≥48** numeric escapes that **decode to a high-entropy BYTE payload**. The byte-range + entropy gate (mirroring A) is what keeps it clean: emoji/CJK/combining-mark tables are >255 narrow-block codepoints, and magic-byte/file-header fixtures are low-entropy/short.

## Adversarial verification drove the design

An FP-hunt + evasion workflow found — and the fixes were each confirmed empirically:

| Found | Fix | Confirmed |
|---|---|---|
| B at threshold 24 (length-only) flips clean repos INFECTED on 12-emoji rows, PNG magic-byte fixtures, 32-byte crypto KAT vectors (all in scanned `test/` paths) | `_MIN_ESCAPE_RUN` → **48** + decoded byte-range/entropy gate | each now clean ✓ |
| `["c1","c2",…].join("")` (canonical obfuscator output) evades an `+`-only de-chunker | collapse **comma seams** too | now caught ✓ |

**Rejected** the reviewer's "path-scope `test/`/`fixtures/`" idea — it would create a **malware blind spot** (drop the payload in `__tests__/`). Documented residuals instead.

## Honest residual boundaries

- A **≥48-byte high-entropy crypto KAT** written as `\xNN` is byte-range + high-entropy → stays a **rare, medium-severity, human-triageable** finding (genuinely indistinguishable from a payload statically).
- **template-literal** `${a}${b}` reassembly (chunks live in variables) and **ascii85 / non-`+`-charset** encodings are not statically reassembled — the next boundary.

## Tests

+10 (chunked-base64, `.join`-array, escape-byte payload, chunked-escape; FP guards: emoji surrogate run, magic-byte fixture, combining marks, legit string array, short concat, few escapes). Full suite **166 pass**; #1053 fixture still INFECTED, clean fixture still clean.

Refs #1053.