### PR TITLE
feat(security): confidence-graded verdict — INFECTED only when sure, else SUSPICIOUS

### DIFF
--- a/src/stayawake/bots/security/alerter.py
+++ b/src/stayawake/bots/security/alerter.py
@@ -56,7 +56,11 @@ def run(latest_path: str | Path = "reports/security/latest.json") -> None:
 
     results = latest.get("results", [])
     infected = [r for r in results if r.get("infected")]
-    clean = [r for r in results if not r.get("infected") and not r.get("error")]
+    suspicious = [r for r in results if r.get("suspicious")]
+    # A suspicious repo is neither infected nor clean: don't auto-close its issue, and
+    # (below) don't open one either — only confirmed-infected repos get a GitHub issue.
+    clean = [r for r in results if not r.get("infected")
+             and not r.get("suspicious") and not r.get("error")]
 
     if infected and slack:
         send_slack(slack, {"text": "StayAwakeBot Security Sentinel", "attachments": [{
@@ -65,9 +69,18 @@ def run(latest_path: str | Path = "reports/security/latest.json") -> None:
             "text": "\n".join(f"• {r['target']} — {r['summary']['total']} findings "
                               f"({r['summary']['max_severity']})" for r in infected[:20]),
             "footer": f"StayAwakeBot Security Sentinel | {utc_stamp()}"}]})
+    if suspicious and slack:
+        # Softer, distinct alert — informs without crying "malware" on heuristic-only hits.
+        send_slack(slack, {"text": "StayAwakeBot Security Sentinel", "attachments": [{
+            "color": "#dbab09",
+            "title": f"🟡 {len(suspicious)} repo(s) with items to review (not confirmed)",
+            "text": "\n".join(f"• {r['target']} — {r['summary']['total']} heuristic finding(s)"
+                              for r in suspicious[:20]),
+            "footer": f"StayAwakeBot Security Sentinel | {utc_stamp()}"}]})
 
     if not (token and repo):
-        print(f"Security alerts: {len(infected)} infected (no token/repo — skipped GitHub issues).")
+        print(f"Security alerts: {len(infected)} infected, {len(suspicious)} suspicious "
+              "(no token/repo — skipped GitHub issues).")
         return
 
     owner, name = repo.split("/")
@@ -83,4 +96,5 @@ def run(latest_path: str | Path = "reports/security/latest.json") -> None:
         if it and it.get("number") is not None:
             github_api.request(f"/repos/{owner}/{name}/issues/{it['number']}",
                                method="PATCH", token=token, data={"state": "closed"})
-    print(f"Security alerts processed: {len(infected)} infected, {len(clean)} clean.")
+    print(f"Security alerts processed: {len(infected)} infected, "
+          f"{len(suspicious)} suspicious, {len(clean)} clean.")

--- a/src/stayawake/bots/security/data/signatures.yml
+++ b/src/stayawake/bots/security/data/signatures.yml
@@ -12,6 +12,11 @@
 #   description human-readable
 #   remediation strategy id (consumed in Phase 3): strip-appended-payload |
 #               quarantine-file | quarantine-dir | remove-foreign-vscode | strip-gitignore-markers | manual
+#   confidence  verdict weight (OPTIONAL, default `confirmed`): confirmed | heuristic.
+#               Orthogonal to severity. Only a `confirmed` match drives an INFECTED
+#               verdict; a `heuristic` match (a SHAPE benign code can share — a packed
+#               blob, an oversized line, a review-evading merge) surfaces as SUSPICIOUS
+#               so the user is informed without a false "infected" alarm. See models.py.
 version: 1
 
 signatures:
@@ -90,6 +95,7 @@ signatures:
     category: code-loader
     severity: medium
     matcher: heuristic
+    confidence: heuristic
     kind: long-line
     threshold: 2000
     file_globs: ["*.mjs", "*.cjs", "*.js", "*.ts", "postcss.config.*"]
@@ -106,6 +112,7 @@ signatures:
     category: code-loader
     severity: medium
     matcher: obfuscation
+    confidence: heuristic
     kind: obfuscated-file
     description: "Hand-authored source/config file containing packed/obfuscated payload (line-agnostic)"
     remediation: strip-appended-payload
@@ -150,6 +157,7 @@ signatures:
     category: evil-merge
     severity: high
     matcher: git-history
+    confidence: heuristic
     kind: evil-merge
     description: "Merge commit introducing content beyond a clean 3-way merge of its parents (review-evading)"
     remediation: manual

--- a/src/stayawake/bots/security/models.py
+++ b/src/stayawake/bots/security/models.py
@@ -15,6 +15,22 @@ from typing import Any
 # (excludes it from scans). Keep these in sync via this constant only.
 QUARANTINE_DIR = ".malware-quarantine"
 
+# ── Finding confidence — orthogonal to severity (the verdict tier) ───────────────
+# Only a `confirmed` finding — a signature specific enough to be decisive on its own
+# (a known loader literal, the worm's exact tooling markers, an autorun harness) —
+# drives an INFECTED verdict. A `heuristic` finding matches a SHAPE that benign code can
+# also have (a packed/encoded blob, an oversized config line, a review-evading merge);
+# it is surfaced as SUSPICIOUS so the user is informed, but never alone asserts
+# "infected". This keeps the verdict honest: we only say malware when we are sure.
+CONFIRMED = "confirmed"
+HEURISTIC = "heuristic"
+CONFIDENCE_LEVELS = (CONFIRMED, HEURISTIC)
+
+# Repo verdict states (a graded replacement for the old infected/clean boolean).
+CLEAN = "clean"
+SUSPICIOUS = "suspicious"
+INFECTED = "infected"
+
 
 class Severity(IntEnum):
     """Ordered so thresholds can compare numerically (CRITICAL is highest)."""
@@ -48,6 +64,7 @@ class Finding:
     line: int | None = None
     evidence: str | None = None
     vector: str | None = None      # e.g. "vscode-autorun", "evil-merge"
+    confidence: str = CONFIRMED    # confirmed | heuristic — stamped by the scanner from the signature
 
     def to_dict(self) -> dict[str, Any]:
         d = asdict(self)
@@ -65,8 +82,29 @@ class ScanResult:
     error: str | None = None
 
     @property
+    def verdict(self) -> str:
+        """Three-state, confidence-graded repo verdict.
+
+        INFECTED only when at least one CONFIRMED finding is present (a signature
+        decisive on its own). Findings that are all HEURISTIC — a shape benign code can
+        share — are SUSPICIOUS: surfaced for review, but never asserted as malware. This
+        is the honest replacement for the old `bool(findings)`, which labelled a base64
+        avatar or a crypto test vector "infected"."""
+        if not self.findings:
+            return CLEAN
+        if any(f.confidence == CONFIRMED for f in self.findings):
+            return INFECTED
+        return SUSPICIOUS
+
+    @property
     def infected(self) -> bool:
-        return bool(self.findings)
+        """Back-compat boolean: True only for a CONFIRMED-driven INFECTED verdict, so
+        every existing consumer (CI gate, alerter, reports) stops firing on heuristics."""
+        return self.verdict == INFECTED
+
+    @property
+    def suspicious(self) -> bool:
+        return self.verdict == SUSPICIOUS
 
     @property
     def max_severity(self) -> Severity | None:
@@ -75,13 +113,16 @@ class ScanResult:
     def summary(self) -> dict[str, Any]:
         by_sev: dict[str, int] = {}
         by_cat: dict[str, int] = {}
+        by_conf: dict[str, int] = {}
         for f in self.findings:
             by_sev[f.severity.label()] = by_sev.get(f.severity.label(), 0) + 1
             by_cat[f.category] = by_cat.get(f.category, 0) + 1
+            by_conf[f.confidence] = by_conf.get(f.confidence, 0) + 1
         return {
             "total": len(self.findings),
             "by_severity": by_sev,
             "by_category": by_cat,
+            "by_confidence": by_conf,
             "max_severity": self.max_severity.label() if self.max_severity else None,
         }
 
@@ -89,7 +130,9 @@ class ScanResult:
         return {
             "target": self.target,
             "source": self.source,
+            "verdict": self.verdict,
             "infected": self.infected,
+            "suspicious": self.suspicious,
             "error": self.error,
             "summary": self.summary(),
             "findings": [f.to_dict() for f in self.findings],

--- a/src/stayawake/bots/security/remediation.py
+++ b/src/stayawake/bots/security/remediation.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from stayawake.bots.security.matchers.base import load_jsonc
-from stayawake.bots.security.models import QUARANTINE_DIR
+from stayawake.bots.security.models import HEURISTIC, QUARANTINE_DIR
 
 # remediation id → internal action
 _ACTIONS = {
@@ -43,7 +43,13 @@ _QUARANTINE_PATTERNS = (QUARANTINE_DIR + "/",)
 
 
 def is_auto_fixable(finding) -> bool:
-    """True if a finding has a known automatic remediation (i.e. not `manual`)."""
+    """True if a finding has a known automatic remediation AND we are confident enough to
+    auto-edit. A HEURISTIC finding (a packed-blob / oversized-line shape a base64 asset or
+    crypto vector also produces) is surfaced but NEVER auto-stripped — auto-editing a file
+    we are not sure is malicious is exactly how a false positive becomes a corrupted file.
+    Such findings fall through to the manual list instead."""
+    if getattr(finding, "confidence", "confirmed") == HEURISTIC:
+        return False
     return getattr(finding, "remediation", "manual") in _ACTIONS
 
 
@@ -71,9 +77,9 @@ def plan(findings) -> list[Change]:
     """Map findings to a deduped list of changes (pure — no filesystem access)."""
     changes: dict[tuple[str, str], Change] = {}
     for f in findings:
-        action = _ACTIONS.get(getattr(f, "remediation", "manual"))
-        if action is None:
-            continue                      # manual (e.g. evil-merge) — not auto-fixed
+        if not is_auto_fixable(f):
+            continue                      # manual (e.g. evil-merge) or heuristic — not auto-fixed
+        action = _ACTIONS[getattr(f, "remediation", "manual")]
         path = f.path
         if f.remediation == "quarantine-dir":
             path = _fonts_dir(f.path)

--- a/src/stayawake/bots/security/remediator.py
+++ b/src/stayawake/bots/security/remediator.py
@@ -84,7 +84,10 @@ def remediate(config_path: str = "config/security.yml", apply: bool = False,
     for repo in discover_local_repos(cfg.get("targets", {}).get("local", []), opts):
         result = scan_target(LocalRepoTarget(repo, str(repo), opts), sigs, allowlist)
         changes = remediation.plan(result.findings)
-        manual = [f for f in result.findings if f.remediation == "manual"]
+        # Everything not auto-fixed — true `manual` findings AND heuristic ones we refuse
+        # to auto-edit — surfaces here so a suspicious match is reviewed, never silently
+        # stripped or silently dropped.
+        manual = [f for f in result.findings if not remediation.is_auto_fixable(f)]
         if not changes and not manual:
             continue
         rel = str(repo).replace(str(Path.home()), "~")

--- a/src/stayawake/bots/security/reporter.py
+++ b/src/stayawake/bots/security/reporter.py
@@ -18,17 +18,22 @@ def generate(latest_path: str | Path = "reports/security/latest.json",
         print("security latest.json not found; run the scanner first")
         return
     summary = latest.get("summary", {})
+    def _digest(r):
+        return {"target": r["target"], "source": r["source"],
+                "findings": r["summary"]["total"], "max_severity": r["summary"]["max_severity"]}
+
+    results = latest.get("results", [])
     status = {
         "generated_at": latest.get("generated_at"),
         "summary": summary,
-        "infected": [
-            {"target": r["target"], "source": r["source"],
-             "findings": r["summary"]["total"], "max_severity": r["summary"]["max_severity"]}
-            for r in latest.get("results", []) if r.get("infected")
-        ],
+        "infected": [_digest(r) for r in results if r.get("infected")],
+        # Surfaced for visibility (review), but distinct from infected — these are
+        # heuristic-only matches, never asserted as malware.
+        "suspicious": [_digest(r) for r in results if r.get("suspicious")],
     }
     rdir = resolve_reports_dir(reports_dir, default="reports/security",
                                label="security reports")
     write_json(rdir / "status.json", status)
     print(f"Security status updated ({summary.get('infected', 0)} infected, "
+          f"{summary.get('suspicious', 0)} suspicious, "
           f"{summary.get('findings', 0)} findings).")

--- a/src/stayawake/bots/security/scanner.py
+++ b/src/stayawake/bots/security/scanner.py
@@ -10,7 +10,7 @@ import inspect
 from fnmatch import fnmatch
 from typing import Any
 
-from stayawake.bots.security.models import Finding, ScanResult
+from stayawake.bots.security.models import CONFIRMED, HEURISTIC, Finding, ScanResult
 from stayawake.bots.security.matchers import REGISTRY
 
 
@@ -50,6 +50,12 @@ def scan_target(target, signatures_by_matcher: dict[str, list[dict[str, Any]]],
     # matchers' signatures (the evil-merge detector cross-checks the content-loader
     # fingerprints) can reach them without re-loading the DB.
     all_sigs = [s for group in signatures_by_matcher.values() for s in group]
+    # Confidence is a property of the signature, not the matcher, so stamp it centrally
+    # here (one source of truth) rather than threading it through every matcher. Anything
+    # not explicitly marked `heuristic` is treated as `confirmed` — the conservative
+    # default, so a new signature can never silently downgrade itself out of INFECTED.
+    confidence_of = {s["id"]: (HEURISTIC if s.get("confidence") == HEURISTIC else CONFIRMED)
+                     for s in all_sigs}
     try:
         for matcher_name, sigs in signatures_by_matcher.items():
             matcher = REGISTRY.get(matcher_name)
@@ -60,6 +66,7 @@ def scan_target(target, signatures_by_matcher: dict[str, list[dict[str, Any]]],
                         else matcher.scan(target, sigs))
             for finding in findings:
                 if not _allowed(finding, allowlist or []):
+                    finding.confidence = confidence_of.get(finding.signature_id, CONFIRMED)
                     result.findings.append(finding)
         # Stable, useful ordering: severity desc, then path.
         result.findings.sort(key=lambda f: (-int(f.severity), f.path))

--- a/src/stayawake/bots/security/service.py
+++ b/src/stayawake/bots/security/service.py
@@ -79,11 +79,17 @@ def _render_markdown(payload: dict) -> str:
     s = payload["summary"]
     out = [f"# Security scan — {payload['generated_at']}", "",
            f"**{s['targets']} targets** · {s['infected']} infected · "
+           f"{s.get('suspicious', 0)} suspicious · "
            f"{s['findings']} findings ({s['critical']} critical, {s['high']} high)", "",
+           "_Verdict: **infected** = a confirmed (high-confidence) signature matched; "
+           "**suspicious** = only heuristic match(es) that benign code can also produce — "
+           "review, not asserted as malware._", "",
            "| Target | Source | Status | Findings | Top severity |",
            "|--------|--------|--------|----------|--------------|"]
     for r in payload["results"]:
-        status = "❌ INFECTED" if r["infected"] else ("⚠️ error" if r["error"] else "✅ clean")
+        status = ("❌ INFECTED" if r["infected"]
+                  else "🟡 SUSPICIOUS" if r.get("suspicious")
+                  else "⚠️ error" if r["error"] else "✅ clean")
         out.append(f"| {r['target']} | {r['source']} | {status} | "
                    f"{r['summary']['total']} | {r['summary']['max_severity'] or '—'} |")
     out += ["", "## Findings", ""]
@@ -95,7 +101,8 @@ def _render_markdown(payload: dict) -> str:
         out.append(f"### {r['target']}")
         for f in r["findings"]:
             loc = f["path"] + (f":{f['line']}" if f.get("line") else "")
-            out.append(f"- **[{f['severity']}]** `{f['signature_id']}` — {loc}")
+            out.append(f"- **[{f['severity']} · {f.get('confidence', 'confirmed')}]** "
+                       f"`{f['signature_id']}` — {loc}")
             out.append(f"  - {f['description']}")
             if f.get("evidence"):
                 out.append(f"  - evidence: `{f['evidence']}`")
@@ -176,11 +183,13 @@ def scan(config_path: str | None = None, local_only: bool = False,
         "summary": {
             "targets": len(results),
             "infected": sum(1 for r in results if r.infected),
+            "suspicious": sum(1 for r in results if r.suspicious),
             "findings": sum(len(r.findings) for r in results),
             "critical": sum(1 for r in results for f in r.findings if f.severity.label() == "critical"),
             "high": sum(1 for r in results for f in r.findings if f.severity.label() == "high"),
         },
         "any_infected": any(r.infected for r in results),
+        "any_suspicious": any(r.suspicious for r in results),
         "results": [r.to_dict() for r in results],
     }
     rdir = resolve_reports_dir(reports_dir, settings_value=settings.get("reports_dir"),
@@ -190,9 +199,16 @@ def scan(config_path: str | None = None, local_only: bool = False,
 
     s = payload["summary"]
     print(f"Scanned {s['targets']} target(s): {s['infected']} infected, "
+          f"{s['suspicious']} suspicious, "
           f"{s['findings']} findings ({s['critical']} critical, {s['high']} high)")
     for r in results:
-        tag = "INFECTED" if r.infected else ("ERROR" if r.error else "clean")
+        tag = ("INFECTED" if r.infected else "SUSPECT" if r.suspicious
+               else "ERROR" if r.error else "clean")
         print(f"  [{tag:8}] {r.target}  ({len(r.findings)} findings)")
+    if s["suspicious"]:
+        print("  ↳ 'suspicious' = heuristic match(es) to review; not asserted as infected. "
+              "See reports/security/latest.md.")
 
+    # Gate fails on INFECTED only (confirmed findings). Whether SUSPICIOUS should also
+    # fail the gate is a CI policy decision tracked in #1058, intentionally not changed here.
     return 1 if (fail_on_findings and payload["any_infected"]) else 0

--- a/src/stayawake/bots/security/signatures.py
+++ b/src/stayawake/bots/security/signatures.py
@@ -16,6 +16,7 @@ from typing import Any
 import yaml
 
 from stayawake.bots.security.matchers import REGISTRY
+from stayawake.bots.security.models import CONFIDENCE_LEVELS
 
 _REQUIRED = ("id", "category", "severity", "matcher", "description")
 
@@ -48,5 +49,9 @@ def load_signatures(path: str | Path | None = None) -> dict[str, list[dict[str, 
         seen.add(s["id"])
         if s["matcher"] not in REGISTRY:
             raise ValueError(f"Unknown matcher '{s['matcher']}' in signature {s['id']}")
+        conf = s.get("confidence")
+        if conf is not None and conf not in CONFIDENCE_LEVELS:
+            raise ValueError(
+                f"Signature {s['id']}: invalid confidence '{conf}' (use one of {CONFIDENCE_LEVELS})")
         grouped[s["matcher"]].append(s)
     return dict(grouped)

--- a/tests/bots/security/test_verdict.py
+++ b/tests/bots/security/test_verdict.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Confidence-graded verdict: INFECTED only for a `confirmed` finding; heuristic-only
+matches surface as SUSPICIOUS (informed, never asserted as malware). This is what keeps
+the scanner from labelling a base64 asset / crypto test vector "infected"."""
+from __future__ import annotations
+
+import random
+import tempfile
+import unittest
+from pathlib import Path
+
+from stayawake.bots.security.models import (
+    Finding, ScanResult, Severity, CONFIRMED, HEURISTIC, CLEAN, SUSPICIOUS, INFECTED,
+)
+from stayawake.bots.security import remediation
+from stayawake.bots.security.signatures import load_signatures
+from stayawake.bots.security.scanner import scan_target
+from stayawake.bots.security.targets import LocalRepoTarget, ScanOptions
+
+SIGS = load_signatures()
+
+
+def _finding(sig_id, sev=Severity.MEDIUM, confidence=CONFIRMED, remediation="manual"):
+    return Finding(signature_id=sig_id, category="code-loader", severity=sev,
+                   path="x.ts", description="d", remediation=remediation, confidence=confidence)
+
+
+def _scan(files):
+    d = Path(tempfile.mkdtemp())
+    for rel, c in files.items():
+        p = d / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(c, encoding="utf-8")
+    return scan_target(LocalRepoTarget(d, "t", ScanOptions()), SIGS, [])
+
+
+class TestVerdict(unittest.TestCase):
+    # ── The core rule: only confirmed → infected ────────────────────────────────
+    def test_no_findings_is_clean(self):
+        r = ScanResult(target="t", source="local")
+        self.assertEqual(r.verdict, CLEAN)
+        self.assertFalse(r.infected)
+        self.assertFalse(r.suspicious)
+
+    def test_heuristic_only_is_suspicious_not_infected(self):
+        r = ScanResult(target="t", source="local",
+                       findings=[_finding("obfuscated-source-file", confidence=HEURISTIC)])
+        self.assertEqual(r.verdict, SUSPICIOUS)
+        self.assertFalse(r.infected)
+        self.assertTrue(r.suspicious)
+
+    def test_any_confirmed_is_infected(self):
+        r = ScanResult(target="t", source="local",
+                       findings=[_finding("loader-seed-var", Severity.CRITICAL, CONFIRMED)])
+        self.assertEqual(r.verdict, INFECTED)
+        self.assertTrue(r.infected)
+
+    def test_confidence_is_independent_of_severity(self):
+        # A CONFIRMED *medium* IOC (the worm's exact tooling markers) is INFECTED, while a
+        # HEURISTIC *high* finding (evil-merge) is only SUSPICIOUS. Severity != confidence.
+        ioc = ScanResult(target="t", source="local",
+                         findings=[_finding("gitignore-autopush-markers", Severity.MEDIUM, CONFIRMED)])
+        heur_high = ScanResult(target="t", source="local",
+                               findings=[_finding("evil-merge", Severity.HIGH, HEURISTIC)])
+        self.assertEqual(ioc.verdict, INFECTED)
+        self.assertEqual(heur_high.verdict, SUSPICIOUS)
+
+    def test_mixed_confirmed_and_heuristic_is_infected(self):
+        r = ScanResult(target="t", source="local", findings=[
+            _finding("obfuscated-source-file", confidence=HEURISTIC),
+            _finding("loader-global-bang", Severity.HIGH, CONFIRMED),
+        ])
+        self.assertEqual(r.verdict, INFECTED)
+
+    def test_many_heuristics_never_escalate_to_infected(self):
+        # No count-based escalation: three independent heuristic hits stay SUSPICIOUS.
+        r = ScanResult(target="t", source="local",
+                       findings=[_finding("obfuscated-source-file", confidence=HEURISTIC) for _ in range(3)])
+        self.assertEqual(r.verdict, SUSPICIOUS)
+
+    def test_to_dict_exposes_verdict(self):
+        r = ScanResult(target="t", source="local",
+                       findings=[_finding("obfuscated-source-file", confidence=HEURISTIC)])
+        d = r.to_dict()
+        self.assertEqual(d["verdict"], SUSPICIOUS)
+        self.assertFalse(d["infected"])
+        self.assertTrue(d["suspicious"])
+        self.assertEqual(d["findings"][0]["confidence"], HEURISTIC)
+
+    # ── End-to-end through the scanner (confidence stamped from the signature) ──
+    def test_scanner_stamps_confidence_and_grades_assets_suspicious(self):
+        # A base64 asset embedded in source trips only the heuristic obfuscated-source-file.
+        random.seed(2)
+        al = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+        blob = "".join(random.choice(al) for _ in range(400))
+        r = _scan({"avatar.ts": f'export const A = "{blob}";\n'})
+        self.assertEqual(r.verdict, SUSPICIOUS)
+        obf = [f for f in r.findings if f.signature_id == "obfuscated-source-file"]
+        self.assertTrue(obf and all(f.confidence == HEURISTIC for f in obf))
+
+    def test_scanner_grades_real_loader_infected(self):
+        r = _scan({"x.mjs": "var _$_1e42 = sfL(0); String.fromCharCode(127);\n"})
+        self.assertEqual(r.verdict, INFECTED)
+        self.assertTrue(any(f.confidence == CONFIRMED for f in r.findings))
+
+    # ── Remediation safety: heuristic findings never auto-strip ─────────────────
+    def test_heuristic_finding_is_not_auto_fixable(self):
+        heur = _finding("obfuscated-source-file", remediation="strip-appended-payload",
+                        confidence=HEURISTIC)
+        conf = _finding("obfuscated-source-file", remediation="strip-appended-payload",
+                        confidence=CONFIRMED)
+        self.assertFalse(remediation.is_auto_fixable(heur))
+        self.assertTrue(remediation.is_auto_fixable(conf))
+        self.assertEqual(remediation.plan([heur]), [])      # no auto-edit planned
+        self.assertTrue(remediation.plan([conf]))           # confirmed one is planned
+
+
+class TestConfidenceSignatureValidation(unittest.TestCase):
+    def test_invalid_confidence_value_fails_loudly(self):
+        bad = ("version: 1\nsignatures:\n"
+               "  - id: x\n    category: code-loader\n    severity: medium\n"
+               "    matcher: content\n    pattern: 'x'\n    description: d\n"
+               "    confidence: definitely-malware\n")
+        with tempfile.NamedTemporaryFile("w", suffix=".yml", delete=False) as fh:
+            fh.write(bad)
+            path = fh.name
+        with self.assertRaises(ValueError):
+            load_signatures(path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> **Answers the question issue #1053** — the confirmed true-positive detection-validation case study (labelled `question`). This PR is the capstone of the **#1060 → #1061 → #1062** arc that answers it: validating the #1053 true positive surfaced that the loader-family heuristics (strengthened for durability in #1060/#1061) could mislabel benign code as `INFECTED`. This verdict tier resolves that — the scanner now only claims "infected" when it is **sure**, and surfaces the rest as `suspicious`. So the detection of the #1053 worm family is now both durable *and* honest.

Answers #1053.

---

## Why

The verdict was `infected = bool(findings)`, so a **single medium heuristic flips a clean repo to INFECTED** — and that drives the CI exit code, **auto-opens a GitHub issue** ("⚠️ Worm indicators"), and pings Slack. A base64 avatar, a PEM key, a crypto KAT vector, or a reflective `x['constructor']()` all tripped it. The scanner was, in effect, **lying**. This makes it honest: claim malware only when sure; surface the rest for review.

## The model

A **confidence** dimension, orthogonal to severity, + a **three-state verdict**:

- **`confidence`** (per signature, declarative in `signatures.yml`, default `confirmed`):
  - `confirmed` — decisive alone: the 5 `loader-*` literals, `gitignore-autopush-markers`, `camouflage-blockchain-readme`, `fake-font-*`, `vscode-*` autorun.
  - `heuristic` — a *shape* benign code can share: `obfuscated-source-file`, `oversized-config-line`, `evil-merge`.
- **`verdict`**: `CLEAN` (no findings) / `SUSPICIOUS` (only heuristic) / `INFECTED` (≥1 confirmed).

**The single rule:** heuristics **never** reach INFECTED on their own — at any count or combination. Only a `confirmed` match does. (No "2 heuristics → infected" escalation, so a base64 asset that trips both `obfuscated-source-file` and `oversized-config-line` stays SUSPICIOUS.)

`infected` is redefined as `verdict == INFECTED`, so every existing consumer (CI gate, alerter, reports) gets the honest semantics with no call-site churn. Confidence is stamped centrally in the scanner (conservative default: anything not marked `heuristic` is `confirmed`).

## Proof — verified end-to-end

| Case | fires | verdict |
|---|---|---|
| base64 asset / reflective `coerce()` | `obfuscated-source-file` (heuristic) | 🟡 **SUSPICIOUS** |
| lone `gitignore-autopush-markers` (**medium** but confirmed IOC) | confirmed | ❌ **INFECTED** |
| real #1053 fixture | 12 confirmed + 2 heuristic | ❌ **INFECTED** |
| clean repo | — | ✅ **CLEAN** |

Confidence ≠ severity: a confirmed *medium* IOC is INFECTED; a heuristic *high* (`evil-merge`) is only SUSPICIOUS.

## Surfacing (inform, don't stay quiet)

- Console, `latest.md`, `status.json`, Slack all gain a distinct **SUSPICIOUS** lane; per-finding confidence shown in the report.
- Alerter opens a GitHub issue **only for INFECTED**; SUSPICIOUS gets a softer Slack note and **no** "Worm indicators" issue.
- **Remediation**: heuristic findings are never auto-stripped (`is_auto_fixable` → False) — they fall through to the manual list, so a false positive can't become a **corrupted file**.

## Scope / deferral

CI gate policy unchanged: `-f/--fail` still fails on INFECTED only. Whether SUSPICIOUS should also fail the gate (and map to `::warning`) is a CI policy decision **deferred to #1058** (commented there).

Independent of the open #1061 (Tier-2 detectors) — this grades whatever `obfuscated-source-file` surfaces, including #1061's future reasons.

+11 tests (`test_verdict.py`). Full suite **167 pass**.
