### PR TITLE
feat(security): saw scan --fix (fold remediation into scan) + config-optional fix (#1054)

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -95,7 +95,7 @@ something:
 Hunt for supply-chain worms across one or more repositories or directories.
 
 ```text
-saw scan [PATHS...] [-L] [-c FILE] [-p PATH] [-d DIR] [-f]
+saw scan [PATHS...] [-L] [-c FILE] [-p PATH] [-d DIR] [-f] [--fix [--apply [--pr]]]
 ```
 
 | Option | Description |
@@ -106,13 +106,24 @@ saw scan [PATHS...] [-L] [-c FILE] [-p PATH] [-d DIR] [-f]
 | `-L`, `--local` | Skip remote GitHub targets — scan local paths only. |
 | `-d`, `--reports-dir DIR` | Where to write reports (default: `reports/security`). Use a scratch dir to avoid touching committed reports. |
 | `-f`, `--fail` | Exit `1` if any scanned target is infected (for CI gating). |
+| `--fix` | **Remediate in the same pass** — reuse the scan's findings to fix the scanned local repo(s); no second scan. Dry-run unless `--apply`. |
+| `--apply` | With `--fix`: write fixes (originals backed up to quarantine) and commit them to a branch. Implies `--fix`. |
+| `--pr`, `--open-pr` | With `--fix --apply`: push a fix branch and open/update one rolling, de-duplicated PR per repo. Implies `--fix`. |
 
 ```bash
 saw scan                                  # scan the current repo
 saw scan ./service-a ./service-b          # scan specific paths
 saw scan -L -c config/security.yml        # local-only, configured targets
 saw scan -f                               # gate: non-zero exit on any finding
+saw scan --fix                            # scan AND preview fixes (dry-run), one pass
+saw scan --fix --apply                    # scan and apply fixes, commit to a branch
 ```
+
+> **`scan --fix` is the recommended remediation flow.** It runs detection and remediation
+> from a single analysis pass — there is no re-scan and no report file in between — so a fix
+> always acts on exactly what the scan just found. Only **confirmed** findings are auto-fixed;
+> **suspicious** (heuristic) matches are surfaced for review, never auto-edited. The standalone
+> [`saw fix`](#saw-fix) remains for the org-wide remote sweep and back-compat.
 
 ### `saw run`
 
@@ -160,7 +171,9 @@ Reads credentials from the environment: `SLACK_WEBHOOK_URL`, `GITHUB_TOKEN`, `GI
 ### `saw fix`
 
 Remediate detected worm findings. **Dry-run by default** — it shows what would change unless you
-pass `--apply`.
+pass `--apply`. For the common "scan then fix" flow prefer [`saw scan --fix`](#saw-scan), which
+remediates in the same pass without a second scan; `saw fix` is kept for the **org-wide remote
+sweep** (`--remote`) and back-compat.
 
 ```text
 saw fix [--apply] [--pr] [--remote] [-c FILE]
@@ -172,7 +185,7 @@ saw fix [--apply] [--pr] [--remote] [-c FILE]
 | `--apply` | Write fixes locally (originals backed up) and commit them to a branch. |
 | `--pr` | With `--apply`: push a stable `security/auto-clean` branch and open/update one rolling, de-duplicated PR per repo. |
 | `--remote` | Sweep the configured GitHub targets and open/update a dedup'd fix PR per repo. Needs a GitHub credential with repo + PR write scope (an env token or a `gh auth login` session). |
-| `-c`, `--config FILE` | Config file (default: `config/security.yml`). |
+| `-c`, `--config FILE` | Config file. **Optional** — defaults to `config/security.yml` when present, else the current repository. An explicitly-passed path that does not exist is a clear error (exit `2`), never a crash. |
 
 ```bash
 saw fix                       # dry-run — preview changes

--- a/src/stayawake/bots/security/cli/remediate.py
+++ b/src/stayawake/bots/security/cli/remediate.py
@@ -23,7 +23,8 @@ from stayawake.bots.security import remediator
 
 def main() -> None:
     p = argparse.ArgumentParser(description="StayAwakeBot security remediator")
-    p.add_argument("--config", default="config/security.yml")
+    p.add_argument("--config", default=None,
+                   help="config file (default: config/security.yml when present, else the current repo)")
     p.add_argument("--apply", action="store_true", help="apply local fixes (default is dry-run)")
     p.add_argument("--open-pr", action="store_true",
                    help="with --apply: push a fix branch and open/update one PR per local repo")

--- a/src/stayawake/bots/security/remediator.py
+++ b/src/stayawake/bots/security/remediator.py
@@ -20,7 +20,7 @@ from stayawake.core import auth
 from stayawake.core import git as gitutil
 from stayawake.bots.security.signatures import load_signatures
 from stayawake.bots.security.scanner import scan_target
-from stayawake.bots.security.service import discover_local_repos
+from stayawake.bots.security.service import discover_local_repos, _enclosing_repo_root, DEFAULT_CONFIG
 from stayawake.bots.security.targets import ScanOptions, LocalRepoTarget
 from stayawake.bots.security.models import QUARANTINE_DIR
 from stayawake.bots.security import remediation
@@ -71,83 +71,120 @@ def _commit_branch(repo: Path, applied) -> str | None:
     return branch
 
 
-def remediate(config_path: str = "config/security.yml", apply: bool = False,
+def _resolve_config(config_path: str | None):
+    """Load the remediation config without ever crashing on a missing file (#1054).
+    None → the packaged default if it exists, else an empty config — so `saw fix` and
+    `saw scan --fix` work on the current repo with no config, mirroring `saw scan`. An
+    explicitly-passed --config that is missing prints a clear, actionable error and
+    returns None (the caller exits non-zero) instead of a raw FileNotFoundError."""
+    if config_path is None:
+        p = Path(DEFAULT_CONFIG)
+        return load_yaml(p) if p.exists() else {}
+    if not Path(config_path).is_file():
+        print(f"error: config '{config_path}' not found. Pass --config <path>, or omit it "
+              "to remediate the current repository.")
+        return None
+    return load_yaml(config_path)
+
+
+def remediate_scanned(repo: Path, result, *, sigs, allowlist, opts,
+                      apply: bool = False, open_pr: bool = False,
+                      token: str | None = None) -> int:
+    """Plan — and with `apply`, write — fixes for ONE already-scanned repo, returning the
+    number of auto-fix changes. The caller supplies the `ScanResult`, so the SAME analysis
+    that produced the report drives the fix: no re-scan, no report-file coupling. Shared by
+    `saw scan --fix` (scans once, then calls this) and `saw fix` (scans, then calls this)."""
+    changes = remediation.plan(result.findings)
+    # Everything not auto-fixed — true `manual` findings AND heuristic ones we refuse to
+    # auto-edit — surfaces here so a suspicious match is reviewed, never silently stripped.
+    manual = [f for f in result.findings if not remediation.is_auto_fixable(f)]
+    if not changes and not manual:
+        return 0
+    rel = str(repo).replace(str(Path.home()), "~")
+    print(f"\n■ {rel}")
+    for c in changes:
+        print(f"    fix  {c.action:14} {c.path}")
+    for f in manual:
+        print(f"    ⚠ manual {f.signature_id}: {f.path} ({f.description[:50]})")
+    if not (apply and changes):
+        return len(changes)
+    if open_pr:
+        if not token:
+            print("    → " + auth.no_credential_hint("opening pull requests") + " Skipped.")
+        else:
+            print(f"    → {pr_submit.submit_fix_pr(repo, opts, sigs, allowlist, token)}")
+        return len(changes)
+    was_clean = _is_clean(repo)
+    quarantine = remediation.quarantine_path(repo)
+    applied = remediation.apply(repo, changes, quarantine)
+    # Post-apply verification: quarantine anything still flagged; never present an
+    # incompletely-cleaned repo as remediated.
+    residual = _residual_auto_fixable(repo, sigs, allowlist, opts)
+    if residual:
+        applied += remediation.quarantine_residual(repo, residual, quarantine)
+        residual = _residual_auto_fixable(repo, sigs, allowlist, opts)
+    remediation.ensure_ignored(repo)       # keep quarantine artifacts out of any commit
+    print(f"    → applied {len(applied)} change(s); originals in {QUARANTINE_DIR}/")
+    if residual:
+        print(f"    → ⚠ {len(residual)} finding(s) still present after remediation; "
+              "left in the working tree for manual review (NOT committed).")
+    elif was_clean:
+        branch = _commit_branch(repo, applied)
+        print(f"    → committed to branch '{branch}'. Review and open a PR (do NOT push to main)."
+              if branch else "    → could not create branch; review `git diff` and commit manually.")
+    else:
+        print("    → repo had uncommitted changes; left in working tree. Review `git diff`, "
+              "then commit to a branch + open a PR.")
+    return len(changes)
+
+
+def remediation_summary(total: int, apply: bool) -> None:
+    """Print the dry-run / applied footer. Shared by `saw fix` and `saw scan --fix`."""
+    if total == 0:
+        print("No auto-remediable findings.")
+    elif not apply:
+        print(f"\nDRY-RUN: {total} change(s) planned across the repos above. Re-run with "
+              "--apply (local branch) or --apply --pr (push a fix branch + open one rolling "
+              "PR per repo, de-duplicated).")
+    else:
+        print(f"\nApplied remediation for {total} change(s). Review the branches/diffs, then open PRs. "
+              "Evil-merge findings (⚠ manual) need a history rewrite — not auto-fixed.")
+
+
+def remediate(config_path: str | None = None, apply: bool = False,
               open_pr: bool = False) -> int:
-    cfg = load_yaml(config_path)
+    """`saw fix`: scan configured/local repos and remediate. Config-optional (#1054) — with
+    no config it falls back to the enclosing repository, mirroring `saw scan`. Returns a
+    process exit code (0 ok; 2 when an explicitly-passed --config is missing)."""
+    cfg = _resolve_config(config_path)
+    if cfg is None:
+        return 2
     settings = cfg.get("settings", {})
     opts = _options(settings)
     sigs = load_signatures(settings.get("signatures_path"))
     allowlist = cfg.get("allowlist", [])
     token, _ = auth.resolve_token()
 
+    # No configured local targets → remediate the repo we're standing in (mirrors `saw scan`).
+    local_patterns = cfg.get("targets", {}).get("local", []) or [str(_enclosing_repo_root())]
     total = 0
-    for repo in discover_local_repos(cfg.get("targets", {}).get("local", []), opts):
+    for repo in discover_local_repos(local_patterns, opts):
         result = scan_target(LocalRepoTarget(repo, str(repo), opts), sigs, allowlist)
-        changes = remediation.plan(result.findings)
-        # Everything not auto-fixed — true `manual` findings AND heuristic ones we refuse
-        # to auto-edit — surfaces here so a suspicious match is reviewed, never silently
-        # stripped or silently dropped.
-        manual = [f for f in result.findings if not remediation.is_auto_fixable(f)]
-        if not changes and not manual:
-            continue
-        rel = str(repo).replace(str(Path.home()), "~")
-        print(f"\n■ {rel}")
-        for c in changes:
-            print(f"    fix  {c.action:14} {c.path}")
-        for f in manual:
-            print(f"    ⚠ manual {f.signature_id}: {f.path} ({f.description[:50]})")
-        total += len(changes)
-
-        if not (apply and changes):
-            continue
-        if open_pr:
-            if not token:
-                print("    → " + auth.no_credential_hint("opening pull requests") + " Skipped.")
-            else:
-                print(f"    → {pr_submit.submit_fix_pr(repo, opts, sigs, allowlist, token)}")
-        else:
-            was_clean = _is_clean(repo)
-            quarantine = remediation.quarantine_path(repo)
-            applied = remediation.apply(repo, changes, quarantine)
-
-            # Post-apply verification: quarantine anything still flagged; never
-            # present an incompletely-cleaned repo as remediated.
-            residual = _residual_auto_fixable(repo, sigs, allowlist, opts)
-            if residual:
-                applied += remediation.quarantine_residual(repo, residual, quarantine)
-                residual = _residual_auto_fixable(repo, sigs, allowlist, opts)
-            remediation.ensure_ignored(repo)   # keep quarantine artifacts out of any commit
-            print(f"    → applied {len(applied)} change(s); originals in {QUARANTINE_DIR}/")
-            if residual:
-                print(f"    → ⚠ {len(residual)} finding(s) still present after remediation; "
-                      "left in the working tree for manual review (NOT committed).")
-                continue
-            if was_clean:
-                branch = _commit_branch(repo, applied)
-                print(f"    → committed to branch '{branch}'. Review and open a PR (do NOT push to main)."
-                      if branch else "    → could not create branch; review `git diff` and commit manually.")
-            else:
-                print("    → repo had uncommitted changes; left in working tree. Review `git diff`, "
-                      "then commit to a branch + open a PR.")
-
-    if total == 0:
-        print("No auto-remediable findings.")
-    elif not apply:
-        print(f"\nDRY-RUN: {total} change(s) planned across the repos above. "
-              "Re-run with --apply (local branch) or --apply --open-pr (push a fix branch + "
-              "open one rolling PR per repo, de-duplicated).")
-    else:
-        print(f"\nApplied remediation for {total} change(s). Review the branches/diffs, then open PRs. "
-              "Evil-merge findings (⚠ manual) need a history rewrite — not auto-fixed.")
-    return total
+        total += remediate_scanned(repo, result, sigs=sigs, allowlist=allowlist, opts=opts,
+                                   apply=apply, open_pr=open_pr, token=token)
+    remediation_summary(total, apply)
+    return 0
 
 
-def submit_org_prs(config_path: str = "config/security.yml", token: str | None = None) -> int:
+def submit_org_prs(config_path: str | None = None, token: str | None = None) -> int:
     """Event-driven / on-demand org sweep: for each configured GitHub repo, open or
     update ONE de-duplicated remediation PR (clean repos are skipped). Returns the
-    number of repos that now have an open fix PR.
+    number of repos that now have an open fix PR. Config-optional (#1054): a missing
+    explicit --config is a clear message (returns 0), never a raw traceback.
     """
-    cfg = load_yaml(config_path)
+    cfg = _resolve_config(config_path)
+    if cfg is None:
+        return 0
     settings = cfg.get("settings", {})
     opts = _options(settings)
     sigs = load_signatures(settings.get("signatures_path"))

--- a/src/stayawake/bots/security/service.py
+++ b/src/stayawake/bots/security/service.py
@@ -129,7 +129,8 @@ def _resolve_remote(cfg: dict, opts: ScanOptions):
 
 def scan(config_path: str | None = None, local_only: bool = False,
          fail_on_findings: bool = False, reports_dir: str | Path | None = None,
-         paths: list[str] | None = None) -> int:
+         paths: list[str] | None = None, fix: bool = False, apply: bool = False,
+         open_pr: bool = False) -> int:
     cfg = _read_config(config_path)
     settings = cfg.get("settings", {})
     opts = _options(settings)
@@ -158,10 +159,13 @@ def scan(config_path: str | None = None, local_only: bool = False,
         print(f"No targets configured; scanning current repository: {local_patterns[0]}")
 
     results: list[ScanResult] = []
+    local_scanned: list[tuple[Path, ScanResult]] = []   # (repo, result) for --fix (no re-scan)
     for repo in discover_local_repos(local_patterns, opts):
         display = str(repo).replace(os.path.expanduser("~"), "~")
         with LocalRepoTarget(repo, display, opts) as t:
-            results.append(scan_target(t, sigs, allowlist))
+            res = scan_target(t, sigs, allowlist)
+        results.append(res)
+        local_scanned.append((repo, res))
 
     if not local_only:
         slugs, token, source = _resolve_remote(cfg, opts)
@@ -208,6 +212,18 @@ def scan(config_path: str | None = None, local_only: bool = False,
     if s["suspicious"]:
         print("  ↳ 'suspicious' = heuristic match(es) to review; not asserted as infected. "
               "See reports/security/latest.md.")
+
+    # --- remediate in the SAME pass (saw scan --fix) — reuse the local results, no re-scan,
+    #     no report-file coupling. Remediation is local-only here; the org-wide remote PR
+    #     sweep stays on `saw fix --remote`. Lazy import avoids a service↔remediator cycle.
+    if fix:
+        from stayawake.bots.security import remediator
+        token = auth.resolve_token()[0] if open_pr else None
+        total = 0
+        for repo, res in local_scanned:
+            total += remediator.remediate_scanned(repo, res, sigs=sigs, allowlist=allowlist,
+                                                   opts=opts, apply=apply, open_pr=open_pr, token=token)
+        remediator.remediation_summary(total, apply)
 
     # Gate fails on INFECTED only (confirmed findings). Whether SUSPICIOUS should also
     # fail the gate is a CI policy decision tracked in #1058, intentionally not changed here.

--- a/src/stayawake/cli/commands/fix.py
+++ b/src/stayawake/cli/commands/fix.py
@@ -8,8 +8,9 @@ from stayawake.bots.security import remediator
 
 
 def register(sub) -> None:
-    p = sub.add_parser("fix", help="remediate findings (dry-run by default)")
-    p.add_argument("-c", "--config", default="config/security.yml")
+    p = sub.add_parser("fix", help="remediate findings (dry-run by default; see also: scan --fix)")
+    p.add_argument("-c", "--config", default=None,
+                   help="config file (default: config/security.yml when present, else the current repo)")
     p.add_argument("--apply", action="store_true",
                    help="apply local fixes (backed up) and commit to a branch")
     p.add_argument("--pr", "--open-pr", action="store_true", dest="pr",
@@ -25,5 +26,5 @@ def run(a: argparse.Namespace) -> int:
         # a successful sweep must still exit 0 (matches the legacy remediate script).
         remediator.submit_org_prs(a.config)
         return 0
-    remediator.remediate(a.config, apply=a.apply, open_pr=a.pr)
-    return 0
+    # remediate() returns a process exit code (0 ok; 2 when an explicit --config is missing).
+    return remediator.remediate(a.config, apply=a.apply, open_pr=a.pr)

--- a/src/stayawake/cli/commands/scan.py
+++ b/src/stayawake/cli/commands/scan.py
@@ -26,9 +26,17 @@ def register(sub) -> None:
     add_scan_args(p)
     p.add_argument("-f", "--fail", "--fail-on-findings", action="store_true", dest="fail",
                    help="exit non-zero if any target is infected (CI gate)")
+    p.add_argument("--fix", action="store_true",
+                   help="also remediate the scanned local repo(s) in the same pass (dry-run)")
+    p.add_argument("--apply", action="store_true",
+                   help="with --fix: write fixes (backed up to quarantine) and commit to a branch")
+    p.add_argument("--pr", "--open-pr", action="store_true", dest="pr",
+                   help="with --fix --apply: push a fix branch and open/update one PR per repo")
     p.set_defaults(func=run)
 
 
 def run(a: argparse.Namespace) -> int:
     paths = [*a.paths, *a.extra_paths]
-    return service.scan(a.config, a.local, a.fail, a.reports_dir, paths or None)
+    fix = a.fix or a.apply or a.pr          # --apply/--pr imply --fix
+    return service.scan(a.config, a.local, a.fail, a.reports_dir, paths or None,
+                        fix=fix, apply=a.apply, open_pr=a.pr)

--- a/tests/bots/security/test_scan_fix.py
+++ b/tests/bots/security/test_scan_fix.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""`saw scan --fix` and the config-optional remediator (#1054).
+
+Covers: the scan→fix fold (one analysis pass remediates the scanned local repos with
+no re-scan), dry-run safety (no writes without --apply), and that a missing config never
+crashes — None falls back to the current repo, an explicit missing path is a clean exit-2.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+from stayawake.bots.security import service, remediator
+from stayawake.bots.security.scanner import scan_target
+from stayawake.bots.security.signatures import load_signatures
+from stayawake.bots.security.targets import LocalRepoTarget, ScanOptions
+
+# A CONFIRMED, auto-fixable finding: the worm's .gitignore auto-push markers.
+INFECTED_FILES = {".gitignore": "node_modules\ntemp_auto_push.bat\nbranch_structure.json\n"}
+
+
+def _git_repo(files: dict[str, str]) -> Path:
+    d = Path(tempfile.mkdtemp())
+    subprocess.run(["git", "init", "-q", str(d)], check=True)
+    for rel, content in files.items():
+        p = d / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+    return d
+
+
+class TestConfigOptional(unittest.TestCase):
+    def test_no_config_falls_back_to_current_repo_no_crash(self):
+        # #1054: `saw fix` with no config must not raise FileNotFoundError; it falls back
+        # to the enclosing repo and exits cleanly.
+        d = _git_repo(INFECTED_FILES)
+        cwd = os.getcwd()
+        try:
+            os.chdir(d)
+            rc = remediator.remediate(None)          # dry-run, no config
+        finally:
+            os.chdir(cwd)
+        self.assertEqual(rc, 0)
+
+    def test_missing_explicit_config_is_clean_exit_2(self):
+        # An explicitly-passed --config that doesn't exist → exit 2 + message, not a traceback.
+        self.assertEqual(remediator.remediate("definitely-not-here.yml"), 2)
+
+    def test_submit_org_prs_missing_config_returns_zero(self):
+        # The --remote path stays supported and config-optional: clean 0, no crash.
+        self.assertEqual(remediator.submit_org_prs("definitely-not-here.yml"), 0)
+
+
+class TestScanFix(unittest.TestCase):
+    def test_scan_fix_dry_run_plans_without_writing(self):
+        d = _git_repo(INFECTED_FILES)
+        before = (d / ".gitignore").read_text()
+        reports = Path(tempfile.mkdtemp())
+        rc = service.scan(None, local_only=True, paths=[str(d)],
+                          reports_dir=str(reports), fix=True)     # dry-run (no --apply)
+        self.assertEqual((d / ".gitignore").read_text(), before)  # unchanged
+        self.assertIsInstance(rc, int)
+
+    def test_remediate_scanned_reuses_result_no_rescan(self):
+        # The shared engine plans from an already-computed ScanResult (the scan→fix fold).
+        d = _git_repo(INFECTED_FILES)
+        opts = ScanOptions()
+        sigs = load_signatures()
+        result = scan_target(LocalRepoTarget(d, str(d), opts), sigs, [])
+        self.assertTrue(result.findings)
+        changes = remediator.remediate_scanned(d, result, sigs=sigs, allowlist=[], opts=opts)
+        self.assertGreaterEqual(changes, 1)                       # the gitignore strip is planned
+        self.assertEqual((d / ".gitignore").read_text(),
+                         INFECTED_FILES[".gitignore"])            # dry-run: still unchanged
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -71,6 +71,23 @@ class TestScanRouting(unittest.TestCase):
         cli.main(["s", "-f"])
         self.assertTrue(m.call_args.args[2])
 
+    @mock.patch("stayawake.bots.security.service.scan", return_value=0)
+    def test_fix_flags_route_to_service(self, m):
+        cli.main(["scan", "--fix", "--apply", "--pr"])
+        self.assertEqual(m.call_args.kwargs, {"fix": True, "apply": True, "open_pr": True})
+
+    @mock.patch("stayawake.bots.security.service.scan", return_value=0)
+    def test_apply_or_pr_imply_fix(self, m):
+        cli.main(["scan", "--apply"])
+        self.assertTrue(m.call_args.kwargs["fix"])
+        cli.main(["scan", "--pr"])
+        self.assertTrue(m.call_args.kwargs["fix"])
+
+    @mock.patch("stayawake.bots.security.service.scan", return_value=0)
+    def test_bare_scan_does_not_fix(self, m):
+        cli.main(["scan"])
+        self.assertFalse(m.call_args.kwargs["fix"])
+
 
 class TestSecNamespace(unittest.TestCase):
     @mock.patch("stayawake.bots.security.service.scan", return_value=0)
@@ -109,13 +126,18 @@ class TestReportAlert(unittest.TestCase):
 
 
 class TestFix(unittest.TestCase):
-    @mock.patch("stayawake.bots.security.remediator.remediate")
+    @mock.patch("stayawake.bots.security.remediator.remediate", return_value=0)
     def test_local_apply_pr(self, m):
         rc = cli.main(["fix", "--apply", "--pr"])
-        self.assertEqual(rc, 0)
+        self.assertEqual(rc, 0)                  # fix now propagates remediate()'s exit code
         self.assertEqual(m.call_args.kwargs, {"apply": True, "open_pr": True})
 
-    @mock.patch("stayawake.bots.security.remediator.remediate")
+    @mock.patch("stayawake.bots.security.remediator.remediate", return_value=2)
+    def test_missing_explicit_config_exits_nonzero(self, _):
+        # #1054: a missing --config is a clean exit-2, not a crash; fix propagates it.
+        self.assertEqual(cli.main(["fix", "--config", "nope.yml"]), 2)
+
+    @mock.patch("stayawake.bots.security.remediator.remediate", return_value=0)
     def test_open_pr_legacy_alias(self, m):
         cli.main(["fix", "--apply", "--open-pr"])
         self.assertTrue(m.call_args.kwargs["open_pr"])


### PR DESCRIPTION
## What

Folds remediation into scan so the natural flow works in one pass, and fixes the #1054 crash.

- `saw scan --fix` → scan **and** preview fixes in one analysis pass (dry-run)
- `saw scan --fix --apply` → …and write them (quarantine backup + commit to a fix branch)
- `saw scan --fix --apply --pr` → …and push a branch + open one rolling PR per repo

## Why this design

We looked at how mature CLIs handle "command A detects, command B remediates":
- **eslint / ruff / prettier / cargo fix** — one command with `--fix`, sharing one analysis (no state).
- **npm audit fix / kubectl apply / terraform / git apply** — re-derive from or **re-validate against the source of truth**; never trust an incidental report.
- **gh** — stateless, explicit refs, `--json` as the contract; never couples to a side-file.

So we **fold fix into scan** rather than have `fix` consume the report file (brittle the moment reporting changes) or re-scan (redundant — scan already analysed). The shared engine `remediator.remediate_scanned(repo, result, …)` plans/applies from an **already-computed `ScanResult`**, so:
- **no re-scan** (scan's findings drive the fix directly),
- **no report-file coupling** (there's no inter-command handoff),
- the fix acts on **exactly** what was reported.

`saw fix` now calls the same engine (one remediation core, two front doors).

## #1054 — the crash, closed

`saw fix` previously crashed with a raw `FileNotFoundError` when `config/security.yml` was absent. Now config is **optional everywhere**:
- `--config` defaults to `None`; no config → fall back to the **enclosing repo** (mirrors `saw scan`).
- An explicitly-passed missing `--config` → **clear message + exit 2**, never a traceback.
- Applies to `saw fix`, `saw scan --fix`, the `--remote` org sweep (**kept fully supported**), and the legacy remediate script.

Verified end-to-end: `saw fix` from a config-less repo remediates the current repo (exit 0); `saw fix --config missing.yml` → `error: config 'missing.yml' not found …` (exit 2).

## Composition

Builds cleanly on the confidence verdict (#1062): only **confirmed** findings are auto-fixed; **suspicious/heuristic** matches (e.g. `obfuscated-source-file`) surface as `⚠ manual` and are never auto-edited — confirmed live in the smoke test.

## Scope

- **`--remote` org-wide PR sweep stays** on `saw fix` (a genuinely different operation; fully supported).
- **CI gate unchanged** — `-f/--fail` still gates on INFECTED only; the SUSPICIOUS-gating policy stays deferred to #1058.
- Deferred (not needed for this): `saw init` / bundling a default config; the `scan --fix` fold removes the original motivation for consuming a report.

## Tests / docs

+9 tests: `scan --fix` routing (+ `--apply`/`--pr` imply `--fix`, bare scan doesn't fix); config-optional no-crash + explicit-missing exit 2 (local and `--remote`); shared-engine reuse + dry-run-no-write. Full suite **186 pass**. `docs/CLI.md` documents `scan --fix` as the primary remediation flow.

Closes #1054.