### PR TITLE
feat(security): stream scan progress incrementally + typewriter rendering (#1055)

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -106,6 +106,7 @@ saw scan [PATHS...] [-L] [-c FILE] [-p PATH] [-d DIR] [-f] [--fix [--apply [--pr
 | `-L`, `--local` | Skip remote GitHub targets — scan local paths only. |
 | `-d`, `--reports-dir DIR` | Where to write reports (default: `reports/security`). Use a scratch dir to avoid touching committed reports. |
 | `-f`, `--fail` | Exit `1` if any scanned target is infected (for CI gating). |
+| `--no-stream` | Disable the live progress/typewriter output — plain, instant lines. (Auto-off already when piped, in CI, or with `STAYAWAKE_NO_STREAM=1`.) |
 | `--fix` | **Remediate in the same pass** — reuse the scan's findings to fix the scanned local repo(s); no second scan. Dry-run unless `--apply`. |
 | `--apply` | With `--fix`: write fixes (originals backed up to quarantine) and commit them to a branch. Implies `--fix`. |
 | `--pr`, `--open-pr` | With `--fix --apply`: push a fix branch and open/update one rolling, de-duplicated PR per repo. Implies `--fix`. |
@@ -119,6 +120,13 @@ saw scan --fix                            # scan AND preview fixes (dry-run), on
 saw scan --fix --apply                    # scan and apply fixes, commit to a branch
 ```
 
+> **Live progress.** On an interactive terminal, `scan` streams each target as it completes
+> (`[3/9] [INFECTED] …`) with a spinner over the actual work and a typewriter cadence, so a
+> long sweep never looks frozen. It's purely cosmetic pacing of deterministic results — and
+> it **auto-disables** when piped, in CI, with `--no-stream`, or `STAYAWAKE_NO_STREAM=1`, so
+> `stdout` and the report artifacts stay byte-for-byte unchanged. Progress goes to `stderr`;
+> results to `stdout`.
+>
 > **`scan --fix` is the recommended remediation flow.** It runs detection and remediation
 > from a single analysis pass — there is no re-scan and no report file in between — so a fix
 > always acts on exactly what the scan just found. Only **confirmed** findings are auto-fixed;

--- a/src/stayawake/bots/security/service.py
+++ b/src/stayawake/bots/security/service.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 from stayawake.core.config import load_yaml
 from stayawake.core.io import write_json, resolve_reports_dir
+from stayawake.core.streaming import Streamer, status, stream_enabled
 from stayawake.core.timeutil import now_iso
 from stayawake.core.adapters import github_api
 from stayawake.core import auth
@@ -127,10 +128,22 @@ def _resolve_remote(cfg: dict, opts: ScanOptions):
     return sorted(set(slugs)), token, source
 
 
+def _status_tag(r: ScanResult) -> str:
+    """Bracketed, padded verdict tag for a per-target line (INFECTED / SUSPECT / clean)."""
+    tag = ("INFECTED" if r.infected else "SUSPECT" if r.suspicious
+           else "ERROR" if r.error else "clean")
+    return f"[{tag:8}]"
+
+
 def scan(config_path: str | None = None, local_only: bool = False,
          fail_on_findings: bool = False, reports_dir: str | Path | None = None,
          paths: list[str] | None = None, fix: bool = False, apply: bool = False,
-         open_pr: bool = False) -> int:
+         open_pr: bool = False, no_stream: bool = False) -> int:
+    # One streaming decision for the whole command: animate only on an interactive stdout
+    # TTY (and not --no-stream / env-disabled). When off, output is plain and instant and
+    # stdout is byte-identical for any consumer; the spinner (stderr) stays silent.
+    stream_on = stream_enabled(force_off=no_stream)
+    sw = Streamer(enabled=stream_on)
     cfg = _read_config(config_path)
     settings = cfg.get("settings", {})
     opts = _options(settings)
@@ -160,12 +173,20 @@ def scan(config_path: str | None = None, local_only: bool = False,
 
     results: list[ScanResult] = []
     local_scanned: list[tuple[Path, ScanResult]] = []   # (repo, result) for --fix (no re-scan)
-    for repo in discover_local_repos(local_patterns, opts):
+    # Discovery (the FS walk) is itself slow and silent — cover it with a spinner.
+    with status("Discovering repositories…", enabled=stream_on):
+        repos = discover_local_repos(local_patterns, opts)
+    if stream_on and repos:
+        sw.line(f"Found {len(repos)} repositor{'y' if len(repos) == 1 else 'ies'} to scan.")
+    n = len(repos)
+    for i, repo in enumerate(repos, 1):
         display = str(repo).replace(os.path.expanduser("~"), "~")
-        with LocalRepoTarget(repo, display, opts) as t:
-            res = scan_target(t, sigs, allowlist)
+        with status(f"[{i}/{n}] scanning {display}…", enabled=stream_on):  # spinner over real work
+            with LocalRepoTarget(repo, display, opts) as t:
+                res = scan_target(t, sigs, allowlist)
         results.append(res)
         local_scanned.append((repo, res))
+        sw.line(f"  [{i}/{n}] {_status_tag(res)}  {res.target}  ({len(res.findings)} findings)")
 
     if not local_only:
         slugs, token, source = _resolve_remote(cfg, opts)
@@ -174,13 +195,17 @@ def scan(config_path: str | None = None, local_only: bool = False,
         elif slugs:
             print("No GitHub credential found; scanning public remotes anonymously. "
                   "For private repos, run `gh auth login` or set GH_SECURITY_TOKEN.")
-        for slug in slugs:
+        m = len(slugs)
+        for j, slug in enumerate(slugs, 1):
             rt = RemoteRepoTarget(slug, opts, token)
             try:
-                results.append(scan_target(rt, sigs, allowlist) if rt.clone()
-                               else ScanResult(target=slug, source="remote", error="clone failed"))
+                with status(f"[{j}/{m}] cloning + scanning {slug}…", enabled=stream_on):
+                    res = (scan_target(rt, sigs, allowlist) if rt.clone()
+                           else ScanResult(target=slug, source="remote", error="clone failed"))
             finally:
                 rt.cleanup()
+            results.append(res)
+            sw.line(f"  [{j}/{m}] {_status_tag(res)}  {res.target}  ({len(res.findings)} findings)")
 
     payload = {
         "generated_at": now_iso(),
@@ -201,17 +226,15 @@ def scan(config_path: str | None = None, local_only: bool = False,
     write_json(rdir / "latest.json", payload)
     (rdir / "latest.md").write_text(_render_markdown(payload), encoding="utf-8")
 
+    # Per-target lines already streamed during the scan loops above; this is the
+    # authoritative end-of-run recap (unchanged content).
     s = payload["summary"]
-    print(f"Scanned {s['targets']} target(s): {s['infected']} infected, "
-          f"{s['suspicious']} suspicious, "
-          f"{s['findings']} findings ({s['critical']} critical, {s['high']} high)")
-    for r in results:
-        tag = ("INFECTED" if r.infected else "SUSPECT" if r.suspicious
-               else "ERROR" if r.error else "clean")
-        print(f"  [{tag:8}] {r.target}  ({len(r.findings)} findings)")
+    sw.line(f"\nScanned {s['targets']} target(s): {s['infected']} infected, "
+            f"{s['suspicious']} suspicious, "
+            f"{s['findings']} findings ({s['critical']} critical, {s['high']} high)")
     if s["suspicious"]:
-        print("  ↳ 'suspicious' = heuristic match(es) to review; not asserted as infected. "
-              "See reports/security/latest.md.")
+        sw.line("  ↳ 'suspicious' = heuristic match(es) to review; not asserted as infected. "
+                "See reports/security/latest.md.")
 
     # --- remediate in the SAME pass (saw scan --fix) — reuse the local results, no re-scan,
     #     no report-file coupling. Remediation is local-only here; the org-wide remote PR

--- a/src/stayawake/cli/commands/run.py
+++ b/src/stayawake/cli/commands/run.py
@@ -27,7 +27,8 @@ def register(sub) -> None:
 def run(a: argparse.Namespace) -> int:
     reports_dir = resolve_reports_dir(a.reports_dir, default=REPORTS_DIR)
     paths = [*a.paths, *a.extra_paths]
-    code = service.scan(a.config, a.local, a.fail, reports_dir, paths or None)
+    code = service.scan(a.config, a.local, a.fail, reports_dir, paths or None,
+                        no_stream=a.no_stream)
     latest = str(reports_dir / "latest.json")
     reporter.generate(latest_path=latest)
     alerter.run(latest_path=latest)

--- a/src/stayawake/cli/commands/scan.py
+++ b/src/stayawake/cli/commands/scan.py
@@ -19,6 +19,8 @@ def add_scan_args(p: argparse.ArgumentParser) -> None:
                    help="skip remote GitHub targets — scan local paths only")
     p.add_argument("-d", "--reports-dir", default=None, dest="reports_dir",
                    help="where to write reports (default: reports/security)")
+    p.add_argument("--no-stream", action="store_true", dest="no_stream",
+                   help="disable live progress/typewriter output (plain, instant lines)")
 
 
 def register(sub) -> None:
@@ -39,4 +41,4 @@ def run(a: argparse.Namespace) -> int:
     paths = [*a.paths, *a.extra_paths]
     fix = a.fix or a.apply or a.pr          # --apply/--pr imply --fix
     return service.scan(a.config, a.local, a.fail, a.reports_dir, paths or None,
-                        fix=fix, apply=a.apply, open_pr=a.pr)
+                        fix=fix, apply=a.apply, open_pr=a.pr, no_stream=a.no_stream)

--- a/src/stayawake/core/streaming.py
+++ b/src/stayawake/core/streaming.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Typewriter-style streaming writer for human-facing CLI output.
+
+Single responsibility: pace text to a TTY so results *unfold* like writing, with a
+spinner over silent compute phases — while degrading to plain, instant output when
+piped / in CI / disabled. It never changes WHAT is written, only the *cadence*, so
+report artifacts (latest.json / latest.md) and any machine consumer reading stdout are
+byte-for-byte unaffected.
+
+Honest scope: scanner text is computed synchronously, so the typewriter is cosmetic
+pacing of already-known text — not tokens arriving from a model. That is the right call
+for a security tool: detection stays deterministic; only the cadence is animated.
+
+Convention: results go to stdout (Streamer), transient progress to stderr (status).
+"""
+from __future__ import annotations
+
+import itertools
+import os
+import re
+import sys
+import threading
+import time
+from contextlib import contextmanager
+from typing import Iterator, TextIO
+
+_DISABLE_ENV = ("STAYAWAKE_NO_STREAM", "NO_STREAM")
+_WORD = re.compile(r"\S+\s*|\s+")   # a word + its trailing ws, or a run of ws (keeps newlines)
+
+
+def _disabled_by_env() -> bool:
+    return any(os.environ.get(k) for k in _DISABLE_ENV)
+
+
+def _auto_enabled(out: TextIO) -> bool:
+    """Animate only on a real TTY and only when not disabled by env."""
+    if _disabled_by_env():
+        return False
+    try:
+        return bool(out.isatty())
+    except Exception:
+        return False
+
+
+def stream_enabled(out: TextIO | None = None, *, force_off: bool = False) -> bool:
+    """One decision point for a caller: animate iff a TTY, not env-disabled, not forced off
+    (e.g. a --no-stream flag). Callers pass this to both Streamer and status so the whole
+    command animates or stays plain together — deterministic, and silent when stdout is
+    captured (pipes, CI, tests)."""
+    if force_off:
+        return False
+    return _auto_enabled(out or sys.stdout)
+
+
+class Streamer:
+    """Writes text with a typewriter cadence (or instantly when disabled).
+
+    cps:         characters/second target.
+    max_seconds: hard cap on how long ONE write() may animate; long text speeds up to fit.
+    by:          "word" (reads like writing, default) or "char".
+    """
+
+    def __init__(self, *, cps: float = 260.0, max_seconds: float = 1.2,
+                 by: str = "word", out: TextIO | None = None,
+                 enabled: bool | None = None) -> None:
+        self.out = out or sys.stdout
+        self.cps = max(float(cps), 1.0)
+        self.max_seconds = max(float(max_seconds), 0.0)
+        self.by = by if by in ("word", "char") else "word"
+        self.enabled = _auto_enabled(self.out) if enabled is None else bool(enabled)
+
+    def _chunks(self, text: str) -> list[str]:
+        return list(text) if self.by == "char" else _WORD.findall(text)
+
+    def write(self, text: str) -> None:
+        if not text:
+            return
+        if not self.enabled:
+            self.out.write(text)
+            self.out.flush()
+            return
+        delay = 1.0 / self.cps
+        total = len(text) * delay
+        if self.max_seconds and total > self.max_seconds:
+            delay *= self.max_seconds / total          # compress to the cap
+        written = 0
+        try:
+            for chunk in self._chunks(text):
+                self.out.write(chunk)
+                self.out.flush()
+                written += len(chunk)
+                time.sleep(delay * len(chunk))
+        except KeyboardInterrupt:
+            self.out.write(text[written:])             # never leave a half-written line
+            self.out.flush()
+            raise
+
+    def line(self, text: str = "") -> None:
+        self.write(text + "\n")
+
+
+@contextmanager
+def status(label: str, *, out: TextIO | None = None,
+           enabled: bool | None = None, interval: float = 0.08) -> Iterator[None]:
+    """Spinner covering a silent compute phase (FS walk, scanning a repo).
+
+    Enabled → animate a spinner on `out` (default stderr) and wipe the line on exit, so the
+    caller can print the result underneath. Disabled → SILENT (just yields): the result line
+    that follows already conveys completion, so piped/CI output gets no redundant chatter."""
+    out = out or sys.stderr
+    on = _auto_enabled(out) if enabled is None else bool(enabled)
+    if not on:
+        yield
+        return
+
+    frames = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+    stop = threading.Event()
+
+    def spin() -> None:
+        for f in itertools.cycle(frames):
+            if stop.is_set():
+                break
+            out.write(f"\r\033[K{f} {label}")
+            out.flush()
+            time.sleep(interval)
+
+    t = threading.Thread(target=spin, daemon=True)
+    t.start()
+    try:
+        yield
+    finally:
+        stop.set()
+        t.join(timeout=interval * 2)
+        out.write("\r\033[K")                          # wipe the spinner line
+        out.flush()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -74,7 +74,8 @@ class TestScanRouting(unittest.TestCase):
     @mock.patch("stayawake.bots.security.service.scan", return_value=0)
     def test_fix_flags_route_to_service(self, m):
         cli.main(["scan", "--fix", "--apply", "--pr"])
-        self.assertEqual(m.call_args.kwargs, {"fix": True, "apply": True, "open_pr": True})
+        kw = m.call_args.kwargs
+        self.assertTrue(kw["fix"] and kw["apply"] and kw["open_pr"])
 
     @mock.patch("stayawake.bots.security.service.scan", return_value=0)
     def test_apply_or_pr_imply_fix(self, m):

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""core/streaming.py — the typewriter writer + spinner must be byte-for-byte plain when
+disabled (piped / CI / --no-stream / env), so report artifacts and stdout consumers are
+unaffected; only the cadence is animated on a TTY."""
+from __future__ import annotations
+
+import io
+import os
+import unittest
+from unittest import mock
+
+from stayawake.core import streaming
+from stayawake.core.streaming import Streamer, status, stream_enabled
+
+
+class TestStreamerDisabled(unittest.TestCase):
+    def test_disabled_writes_text_verbatim(self):
+        buf = io.StringIO()
+        sw = Streamer(out=buf, enabled=False)
+        sw.write("hello world")
+        sw.line("  [1/2] [INFECTED] ~/a (3 findings)")
+        self.assertEqual(buf.getvalue(),
+                         "hello world  [1/2] [INFECTED] ~/a (3 findings)\n")
+
+    def test_disabled_has_no_escape_codes_or_cr(self):
+        buf = io.StringIO()
+        Streamer(out=buf, enabled=False).line("x")
+        self.assertNotIn("\r", buf.getvalue())
+        self.assertNotIn("\033", buf.getvalue())
+
+    def test_enabled_writes_identical_bytes_just_slower(self):
+        # Even animated, the FULL text emitted is identical — cadence only.
+        buf = io.StringIO()
+        sw = Streamer(out=buf, enabled=True, cps=1e9, max_seconds=0.0, by="word")
+        text = "  [2/9] [clean   ] ~/Dev/web/x  (0 findings)\n"
+        sw.write(text)
+        self.assertEqual(buf.getvalue(), text)
+
+    def test_char_and_word_modes_emit_same_text(self):
+        for by in ("word", "char"):
+            buf = io.StringIO()
+            Streamer(out=buf, enabled=True, cps=1e9, max_seconds=0.0, by=by).write("a b\nc")
+            self.assertEqual(buf.getvalue(), "a b\nc", by)
+
+
+class TestAutoEnable(unittest.TestCase):
+    def test_non_tty_is_disabled(self):
+        self.assertFalse(Streamer(out=io.StringIO()).enabled)        # StringIO isn't a TTY
+
+    def test_stream_enabled_force_off(self):
+        self.assertFalse(stream_enabled(io.StringIO(), force_off=True))
+
+    def test_env_disables_even_on_tty(self):
+        fake_tty = mock.Mock()
+        fake_tty.isatty.return_value = True
+        with mock.patch.dict(os.environ, {"STAYAWAKE_NO_STREAM": "1"}):
+            self.assertFalse(stream_enabled(fake_tty))
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("STAYAWAKE_NO_STREAM", None)
+            self.assertTrue(stream_enabled(fake_tty))
+
+
+class TestStatusSpinner(unittest.TestCase):
+    def test_disabled_is_silent(self):
+        buf = io.StringIO()
+        with status("Discovering…", out=buf, enabled=False):
+            pass
+        self.assertEqual(buf.getvalue(), "")     # silent — the result line conveys progress
+
+    def test_disabled_yields_and_runs_body(self):
+        ran = []
+        with status("x", out=io.StringIO(), enabled=False):
+            ran.append(True)
+        self.assertEqual(ran, [True])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

`saw scan` was **silent from invocation to completion** — on a multi-target sweep the terminal looked frozen, then every line printed in one burst at the end. This streams each target as it's computed, with a spinner over the real work and a typewriter cadence, so a long sweep feels alive.

## New utility — `core/streaming.py` (stdlib-only)

- **`Streamer`** — reveals text with a typewriter cadence (word/char), a chars/sec target, and a hard per-write time cap so even a long evidence line stays snappy.
- **`status(label)`** — a spinner over a silent compute phase (FS walk, scanning a repo).
- **`stream_enabled()`** — the single on/off decision: animate **only** on an interactive TTY; never when piped, in CI, with `--no-stream`, or `STAYAWAKE_NO_STREAM`/`NO_STREAM`.
- **Ctrl-C-safe** (never leaves a half-written line). When disabled it is **byte-for-byte plain and instant** — cadence is the *only* thing animated, so detection stays deterministic and `latest.json`/`latest.md` + any stdout consumer are unaffected.

## Wiring

`service.scan` now emits **as it computes**: a discovery spinner + `Found N`, a per-target `[i/N]` spinner over the scan, then the streamed result line — and the end-of-run summary as the authoritative recap (per-target printing moved *out* of the summary, so no duplication). **Results → stdout; progress/spinner → stderr.** Applies to the local *and* remote loops; `saw run` inherits it. `--no-stream` added (shared by `scan` + `run`).

## Honest scope

Per the issue's follow-up comment: the typewriter is **cosmetic pacing of already-known, synchronously-computed text** — not model tokens. That's the right call for a security tool: detection is deterministic; only the cadence is animated.

## Verified end-to-end

- **On a PTY** (real TTY): animates — braille spinner frames + `\033[K` line-wipes + `Discovering…`/`Found` + streamed `[1/1] [INFECTED] …` + summary.
- **Piped** (non-TTY): `stdout` is plain with **zero** escape codes / `\r`, per-target lines stream during the loop, and **stderr is silent** (no spinner noise).

+9 streaming unit tests (plain-when-disabled, identical-bytes-when-animated, env/force-off gating, silent spinner). Full suite **195 pass**. Docs: `scan` documents live progress + `--no-stream`.

Closes #1055.